### PR TITLE
Add automatic anchor links to all sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,8 @@ extra:
 markdown_extensions:
   - toc:
       toc_depth: 3
+      permalink: true
+      permalink_title: Anchor link to this section for reference
   - admonition
   - attr_list
   - footnotes


### PR DESCRIPTION
Makes it possible to link to specific subsections by clicking on ¶ symbol next to section title and copying link.