### PR TITLE
Update batch-job.md

### DIFF
--- a/docs/computing/jobs/batch-job.md
+++ b/docs/computing/jobs/batch-job.md
@@ -234,6 +234,12 @@ The most common causes are:
 | `--mem-per-cpu`   | Set the memory per allocated CPU cores |
 | `--mem-per-gpu`   | Set the memory per allocated GPU       | 
 
+!!! info                                                                              
+    The `/tmp` directory on the compute nodes resides in memory and is included in    
+    the job memory request. This means that your job can run of memory if you write to
+    much data to `/tmp`                                                               
+
+
 ### Receive email notifications
 
 Email notifications from Slurm can be requested when certain events occur (job

--- a/docs/storage/index.md
+++ b/docs/storage/index.md
@@ -56,6 +56,12 @@ more space if needed.
     files that are no longer needed by your project on a regular basis if you 
     don't want to run out of TB-hours.
 
+## Using compute nodes `/tmp`
+                                                                         
+The `/tmp` directory on the compute nodes resides in memory and is included in
+the job memory request. This means that your job can run of memory if you write
+to much data to `/tmp`   
+
 ## Billing
 
 Storage is billed by volume as well as time. The billing units are TB-hours. For


### PR DESCRIPTION
Note about /tmp being part of the job memory cgroup.

This could perhaps be in some other place? 