### PR TITLE
Updating moving data page to use SSH keys for transferring data. 

### DIFF
--- a/docs/storage/moving/scp-rsync.md
+++ b/docs/storage/moving/scp-rsync.md
@@ -8,26 +8,28 @@ transfer files between a local host and a remote host or between two remote
 hosts. The basic syntax of the `scp` command is the following
 
 ```
-scp <origin-path> <destination-path>
-scp <origin-path> [user@]host:<destination-path>
-scp [user@]host:<origin-path> <destination-path>
+scp -i<path-to-private-key> <origin-path> <destination-path>
+scp -i<path-to-private-key> <origin-path> [user@]host:<destination-path>
+scp -i<path-to-private-key> [user@]host:<origin-path> <destination-path>
 ```
 
 where `<origin-path>` is the path to the file you want to copy to the 
-destination defined by `<destination-path>`.
+destination defined by `<destination-path>`. The `scp` command uses SSH
+to transfer data, therefore the `-i` option is needed to securely connect
+to LUMI, where `<path-to-private-key>` is the path to the *private* ssh key you use to connect to LUMI. 
 
 
 The command to copy a file from a  local machine to a remote host is
 
 ```
-scp /path/to/file [user@]host:/path/to/remote/destination
+scp -i /path/to/ssh-key /path/to/file [user@]host:/path/to/remote/destination
 ```
 
 and correspondingly the syntax to copy files from a remote machine to a local
 machine is
 
 ```
-scp [user@]host:/path/to/file /path/to/local/destination
+scp -i /path/to/ssh-key [user@]host:/path/to/file /path/to/local/destination
 ```
 
 ## Copying files with `rsync`
@@ -50,6 +52,13 @@ rsync <options> <origin-path> [user@]host:<destination-path>
 rsync <options> [user@]host:<origin-path> <destination-path>
 ```
 
+With `rsync` we can use SSH to transfer data using the same identity file that is used to connect to LUMI. This done through the `-e` option.
+
+```
+rsync -e "ssh -i /path/to/ssh-key" [user@]host:/path/to/file /path/to/local/destination
+```
+
+
 Below are some useful options to use with `rsync`:
 
 - archive mode with the `-a` or `--archive` option. This option tells `rsync` to 
@@ -63,3 +72,10 @@ Below are some useful options to use with `rsync`:
 - if your goal is to achieve mirroring use the `--delete` option. When this
   option is used, `rsync` deletes extraneous files from the destination 
   location.
+- If you are having connection issues the `-v` will increase verbosity and may help
+  diagnose the problem. The `-v` flag is also useful for showing what rsync is going, otherwise there is no output unless errors occur. 
+
+You can combine many of these options together into a single flag. Here are some useful examples:
+
+- `rsync -ave "ssh -i /path/to/ssh-key" <origin-path> <destination-path>` - archive mode with verbosity
+- `rsync -avPe "ssh -i /path/to/ssh-key" <origin-path> <destination-path>` - The `-P` flag combines `--partial` and `--progress` which is useful for resuming a transfer and showing a sync's progress in the terminal. 

--- a/docs/storage/moving/scp-rsync.md
+++ b/docs/storage/moving/scp-rsync.md
@@ -74,8 +74,10 @@ Below are some useful options to use with `rsync`:
   location.
 - If you are having connection issues the `-v` will increase verbosity and may help
   diagnose the problem. The `-v` flag is also useful for showing what rsync is going, otherwise there is no output unless errors occur. 
+- `--copy-links` transforms symlink into referent file/dir. This is useful for syncing `/scratch/` and `/projappl/` directories as on LUMI they are symbolic links to the LUSTRE filesystem. 
 
 You can combine many of these options together into a single flag. Here are some useful examples:
 
 - `rsync -ave "ssh -i /path/to/ssh-key" <origin-path> <destination-path>` - archive mode with verbosity
 - `rsync -avPe "ssh -i /path/to/ssh-key" <origin-path> <destination-path>` - The `-P` flag combines `--partial` and `--progress` which is useful for resuming a transfer and showing a sync's progress in the terminal. 
+- `rsync -ahvPe "ssh -i /path/to/ssh-key" --copy-links --delete /projappl/destination-path /path/to/local` - This syncs a folder on your `/projappl/` space with a local directory. The `-h` command specifies humand readable progression and the `--copy-links` is necessary for using `rsync` with any folders in `/projappl/` as they as symbolically linked. 


### PR DESCRIPTION
Added additional instructions for using `scp` and `rsync` to the moving data page. 

- Using the `-i` option for `scp`. This is necessary as LUMI uses ssh keys, there should be some instruction to users on how to use identity files with `scp`.
- Using `-e "ssh -i /path/to/ssh-key"` with `rsync`. This isn't as necessary as with `scp` but users should at least know how to use SSH with `rsync` and using the same identity file they use to connect to LUMI.
- `-v` useful option for rsync. 
- Combining of `rsync` options into a single flag. 

