### PR TITLE
Add available applications under /appl/local

### DIFF
--- a/docs/software/local/csc.md
+++ b/docs/software/local/csc.md
@@ -1,0 +1,23 @@
+# CSC installed software collection
+
+!!! info "Note"
+    Software installed under `/appl/local` are maintained and supported
+    by the respective local organizations.
+
+Load the CSC module tree into use with:
+
+```bash
+module use /appl/local/csc/modulefiles
+```
+
+Available software:
+
+* Amber
+* Elmer
+* OpenFOAM
+* PyTorch
+* TensorFlow
+
+See more details in [Docs CSC](https://docs.csc.fi/apps/by_system/#lumi).
+If you encounter any issues, don't hesitate to contact [CSC Service
+Desk](https://docs.csc.fi/support/contact/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,8 @@ nav:
       - ParaView: https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs/p/ParaView
       - QuantumESPRESSO: https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs/q/QuantumESPRESSO/
       - VASP: https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs/v/VASP/
+    - Local software collections:
+      - CSC: software/local/csc.md
       #- Quantum ESPRESSO: software/guides/quantumespresso.md
       #- ParaView: software/guides/paraview.md
       #- Quantum ESPRESSO: software/guides/quantumespresso.md


### PR DESCRIPTION
Proposal: Add section under Software about applications installed under `/appl/local`. The main idea would just be to list the available applications and point to LO documentation for further details.

Opinions?