### PR TITLE
Link GH logo directly to userguide repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,7 @@ theme:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/Lumi-supercomputer
+      link: https://github.com/Lumi-supercomputer/lumi-userguide/
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/LUMIhpc
 


### PR DESCRIPTION
Instead of GH of LUMI organisations
Closes #73