### PR TITLE
Link to service status page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Help desk: helpdesk/index.md
     - Training and events: helpdesk/training.md
     - Known issues: helpdesk/issues.md
+    - LUMI service status: https://www.lumi-supercomputer.eu/lumi-service-status/
     - Mailing list archive: https://postit.csc.fi/sympa/arc/lumi-users
     
  


### PR DESCRIPTION
Adds a link to the service status page https://www.lumi-supercomputer.eu/lumi-service-status/