### PR TITLE
Update SSH-keys.md

### DIFF
--- a/docs/firststeps/SSH-keys.md
+++ b/docs/firststeps/SSH-keys.md
@@ -117,7 +117,7 @@ start by generating an SSH key pair as detailed below.
     Now that you have generated your key pair, you need to register your
     **public** key in your MyCSC [:material-account: **user profile**][mycsc-profile].
 
-    To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the top right (or left, depending on your device) corner of the page. When you scroll down, you will see a text box on the right-hand side which reads *SSH PUBLIC KEYS*. Click the *Add key* button. Paste the content of you **public** key in the text area which reads *Key*. Omit the ending of the key file that has your local username and the name of your computer. It should look e.g. like
+   To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the left side of the screen. If your browser window is narrow, the navigation might be hidden, in which case you need to open it from the top-right button. In the lower right corner of the *Profile* page there is a box which reads *SSH PUBLIC KEYS*. Click the *Add key* button (you may need to re-login). Paste the content of your **public** key in the text area which reads *Key*. Omit the ending of the key file that has your local username and the name of your computer. It should look like
     
     `ssh-ed25519 AAAAC3NzaC1lZDI....I3J`
     

--- a/docs/firststeps/SSH-keys.md
+++ b/docs/firststeps/SSH-keys.md
@@ -117,7 +117,11 @@ start by generating an SSH key pair as detailed below.
     Now that you have generated your key pair, you need to register your
     **public** key in your MyCSC [:material-account: **user profile**][mycsc-profile].
 
-    To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the left side of the screen. In the lower right corner there is a box which reads *SSH PUBLIC KEYS*. Click the *Add key* button. Paste the content of you **public** key in the text area which reads *Key* and click *Add*. 
+    To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the top right corner of the page. When you scroll down, you will see a text box on the right-hand side which reads *SSH PUBLIC KEYS*. Click the *Add key* button. Paste the content of you **public** key in the text area which reads *Key*. Omit the ending of the key file that has your local username and the name of your computer. It should look like
+    
+    `ssh-ed25519 AAAAC3NzaC1lZDI....I3J`
+    
+    Add a title, e.g., *lumi*, and then click *Add*. 
 
 After registering your SSH key, there can be a couple of hours delay until it
 is synchronized to LUMI and your account is created. **You will receive your

--- a/docs/firststeps/SSH-keys.md
+++ b/docs/firststeps/SSH-keys.md
@@ -117,7 +117,7 @@ start by generating an SSH key pair as detailed below.
     Now that you have generated your key pair, you need to register your
     **public** key in your MyCSC [:material-account: **user profile**][mycsc-profile].
 
-    To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the top right corner of the page. When you scroll down, you will see a text box on the right-hand side which reads *SSH PUBLIC KEYS*. Click the *Add key* button. Paste the content of you **public** key in the text area which reads *Key*. Omit the ending of the key file that has your local username and the name of your computer. It should look like
+    To register your key with [MyCSC][mycsc-profile], click on the *Profile* item of the menu on the top right (or left, depending on your device) corner of the page. When you scroll down, you will see a text box on the right-hand side which reads *SSH PUBLIC KEYS*. Click the *Add key* button. Paste the content of you **public** key in the text area which reads *Key*. Omit the ending of the key file that has your local username and the name of your computer. It should look e.g. like
     
     `ssh-ed25519 AAAAC3NzaC1lZDI....I3J`
     


### PR DESCRIPTION
Maybe my.csc.fi has been rearranged but on my Mac, the profile icon and the menu show up on the right-hand side, not on the left as the guide says. 

For some reason, when I was pasting the full public key file including my username and the host name, it wasn't accepted. Other websites where you paste a public key handle that on their own, and put a default name. Maybe my.csc.fi should also work this way.

And one more suggestion, maybe "regular users" should be changed to "users without a Finnish affiliation". Otherwise, it sounds like we are "irregular". The "regular user" being the first option, I clicked on it right away because I considered myself "regular" before actually reading the neighbouring field. I doubt I'm the only one 😃

(and sorry for the stupid branch name, I forgot to rename the default one)