### PR TITLE
Binding only for full-node allcations

### DIFF
--- a/docs/runjobs/scheduled-jobs/distribution-binding.md
+++ b/docs/runjobs/scheduled-jobs/distribution-binding.md
@@ -3,6 +3,13 @@
 This section is a deep dive into the advanced topic of binding and distributing
 tasks via Slurm on LUMI.
 
+!!! Warning "For full node allocation only"
+
+    This section of the documentation only applies if you have a full-node 
+    allocation. This is the case if you submit to the `standard` and `standard-g`
+    partitions. For other partitions, it will apply if you use the `--exclusive`
+    sbatch directive.
+
 ## Background
 
 [distribution]: #distribution

--- a/docs/runjobs/scheduled-jobs/lumig-job.md
+++ b/docs/runjobs/scheduled-jobs/lumig-job.md
@@ -8,13 +8,16 @@
     reserve 1 core to the operating system. As a consequence only 63 cores
     are available to the jobs. Jobs requesting 64 cores/node will never run.
 
-## MPI-based job
-
 !!! note "GPU Binding"
 
     It is recommended to read the section about [GPU Binding][gpu-binding] for
     more details about the motivation for the binding exemplified is this
-    section.
+    section. Binding only applies if you have a full-node allocation. This is
+    the case if you submit to the `standard` and `standard-g` partitions. For
+    other partitions, it will apply if you use the `--exclusive` sbatch 
+    directive.
+
+## MPI-based job
 
 Below, a job script to launch an application with one MPI rank per GPU (GCD). 
 
@@ -58,12 +61,6 @@ rm -rf ./select_gpu
 ```
 
 ## Hybrid MPI+OpenMP job
-
-!!! note "GPU Binding"
-
-    It is recommended to read the section about [GPU Binding][gpu-binding] for
-    more details about the motivation for the binding exemplified is this
-    section.
 
 Below, a job script to launch an application with one MPI ranks and 6 threads
 per GPU (GCD).


### PR DESCRIPTION
Highlights the fact that CPU and GPU binding only applies if the job allocate a full node.