### PR TITLE
Fix typo in prgenv.md

### DIFF
--- a/docs/development/compiling/prgenv.md
+++ b/docs/development/compiling/prgenv.md
@@ -371,7 +371,7 @@ loaded.
 === "PrgEnv-cray"
 
     ```
-    module load module load PrgEnv-cray
+    module load PrgEnv-cray
     module load craype-accel-amd-gfx90a
     module load rocm
     ```
@@ -379,7 +379,7 @@ loaded.
 === "PrgEnv-amd"
 
     ```
-    module load module load PrgEnv-amd
+    module load PrgEnv-amd
     module load craype-accel-amd-gfx90a
     module load rocm
     ```


### PR DESCRIPTION
`module load` was written twice