### PR TITLE
Add CSC/HAKA LUMI-O authentication info

### DIFF
--- a/docs/storage/lumio/auth-lumidata-eu.md
+++ b/docs/storage/lumio/auth-lumidata-eu.md
@@ -12,8 +12,7 @@ on "-> Go to login".
   <figcaption>auth.lumidata.eu landing page</figcaption>
 </figure>
 
-Choose the correct authentication provider which for LUMI is "MyAccessID" and
-follow the authentication procedure.
+Choose the correct authentication provider which for most LUMI users is "MyAccessID" (users with a Finnish allocation can also use "CSC" or "HAKA"), and follow the authentication procedure.
 
 <figure>
   <img

--- a/docs/storage/lumio/index.md
+++ b/docs/storage/lumio/index.md
@@ -41,8 +41,7 @@ lumio-conf
 
 This command asks you to connect with your browser to the [LUMI-O credentials
 management service](auth-lumidata-eu.md), create credentials there and the copy
-the project number and keys for the setup tool, for authentication use
-**MyAccessID**. The setup process will create configuration files for `s3cmd`
+the project number and keys for the setup tool. The setup process will create configuration files for `s3cmd`
 and `rclone`.
 
 For a step-by-step description, read the [Creating LUMI-O


### PR DESCRIPTION
Small addition to mention that Finnish users can also use CSC/HAKA authentication provider. 