### PR TITLE
Core specialization change after downtime

### DIFF
--- a/docs/runjobs/scheduled-jobs/batch-job.md
+++ b/docs/runjobs/scheduled-jobs/batch-job.md
@@ -7,11 +7,13 @@
 [slurm-man]: https://slurm.schedmd.com/man_index.html
 [slurm-sbatch]: https://slurm.schedmd.com/sbatch.html
 
-!!! warning "Only 63 cores available on LUMI-G"
+!!! warning "Only 56 cores available on LUMI-G"
 
     The LUMI-G compute nodes have the low-noise mode activated. This mode
-    reserve 1 core to the operating system. As a consequence only 63 cores
-    are available to the jobs. Jobs requesting 64 cores/node will never run.
+    reserve 1 core to the operating system. In order to get a more balanced 
+    layout, we also disabled the first core in each of the 8 L3 region. As a
+    consequence only 56 cores are available to the jobs. Jobs requesting 64 
+    cores/node will never run.
 
 This pages covers advanced topics related to running Slurm batch jobs on LUMI.
 If you are not already familiar with Slurm, you should read the [Slurm

--- a/docs/runjobs/scheduled-jobs/distribution-binding.md
+++ b/docs/runjobs/scheduled-jobs/distribution-binding.md
@@ -225,11 +225,13 @@ the manpage: `man srun`.
 
 ### GPU Binding
 
-!!! warning "Only 63 cores available on LUMI-G"
+!!! warning "Only 56 cores available on LUMI-G"
 
     The LUMI-G compute nodes have the low-noise mode activated. This mode
-    reserve 1 core to the operating system. As a consequence only 63 cores
-    are available to the jobs. Jobs requesting 64 cores/node will never run.
+    reserve 1 core to the operating system. In order to get a more balanced 
+    layout, we also disabled the first core in each of the 8 L3 region. As a
+    consequence only 56 cores are available to the jobs. Jobs requesting 64 
+    cores/node will never run.
 
 Correct CPU and GPU binding is important to get the best performance out of the
 GPU nodes. The reason is that each of the 4 NUMA nodes is directly linked to 
@@ -287,10 +289,10 @@ For a hybrid MPI+OpenMP application, the binding can be achieved by launching
 the application using the following command
 
 ```
-CPU_BIND="mask_cpu:ff000000000000,ff00000000000000"
-CPU_BIND="${CPU_BIND},ff0000,ff000000"
-CPU_BIND="${CPU_BIND},fe,ff00"
-CPU_BIND="${CPU_BIND},ff00000000,ff0000000000"
+CPU_BIND="mask_cpu:fe000000000000,fe00000000000000"
+CPU_BIND="${CPU_BIND},fe0000,fe000000"
+CPU_BIND="${CPU_BIND},fe,fe00"
+CPU_BIND="${CPU_BIND},fe00000000,fe0000000000"
 
 srun --cpu-bind=${CPU_BIND} <app> <args>
 ```

--- a/docs/runjobs/scheduled-jobs/lumig-job.md
+++ b/docs/runjobs/scheduled-jobs/lumig-job.md
@@ -38,7 +38,7 @@ Below, a job script to launch an application with one MPI rank per GPU (GCD).
 #SBATCH --error=examplejob.e%j  # Name of stderr error file
 #SBATCH --partition=standard-g  # Partition (queue) name
 #SBATCH --nodes=2               # Total number of nodes 
-#SBATCH --ntasks-per-node=8     # 8 MPI ranks per node, 128 total (16x8)
+#SBATCH --ntasks-per-node=8     # 8 MPI ranks per node, 16 total (2x8)
 #SBATCH --gpus-per-node=8       # Allocate one gpu per MPI rank
 #SBATCH --time=1-12:00:00       # Run time (d-hh:mm:ss)
 #SBATCH --mail-type=all         # Send email at begin and end of job
@@ -84,7 +84,7 @@ per GPU (GCD).
 #SBATCH --error=examplejob.e%j  # Name of stderr error file
 #SBATCH --partition=standard-g  # Partition (queue) name
 #SBATCH --nodes=2               # Total number of nodes 
-#SBATCH --ntasks-per-node=8     # 8 MPI ranks per node, 128 total (16x8)
+#SBATCH --ntasks-per-node=8     # 8 MPI ranks per node, 16 total (2x8)
 #SBATCH --gpus-per-node=8       # Allocate one gpu per MPI rank
 #SBATCH --time=1-12:00:00       # Run time (d-hh:mm:ss)
 #SBATCH --mail-type=all         # Send email at begin and end of job

--- a/docs/runjobs/scheduled-jobs/lumig-job.md
+++ b/docs/runjobs/scheduled-jobs/lumig-job.md
@@ -2,11 +2,13 @@
 
 [gpu-binding]: ../../runjobs/scheduled-jobs/distribution-binding.md#gpu-binding
 
-!!! warning "Only 63 cores available on LUMI-G"
+!!! warning "Only 56 cores available on LUMI-G"
 
     The LUMI-G compute nodes have the low-noise mode activated. This mode
-    reserve 1 core to the operating system. As a consequence only 63 cores
-    are available to the jobs. Jobs requesting 64 cores/node will never run.
+    reserve 1 core to the operating system. In order to get a more balanced 
+    layout, we also disabled the first core in each of the 8 L3 region. As a
+    consequence only 56 cores are available to the jobs. Jobs requesting 64 
+    cores/node will never run.
 
 !!! note "GPU Binding"
 
@@ -52,7 +54,7 @@ EOF
 
 chmod +x ./select_gpu
 
-CPU_BIND="map_cpu:48,56,16,24,1,8,32,40"
+CPU_BIND="map_cpu:49,57,17,25,1,9,33,41"
 
 export MPICH_GPU_SUPPORT_ENABLED=1
 


### PR DESCRIPTION
Prepare documentation for the LUMI-G Slurm configuration changes: enabling core specialization (8 cores disabled, 56 cores available)