### PR TITLE
Update csc.md with info of Allas

### DIFF
--- a/docs/software/local/csc.md
+++ b/docs/software/local/csc.md
@@ -13,6 +13,7 @@ module use /appl/local/csc/modulefiles
 Available software:
 
 * Amber
+* Allas (only for the Finnish national system users)
 * CP2K
 * Elmer
 * GDAL

--- a/docs/software/local/csc.md
+++ b/docs/software/local/csc.md
@@ -13,7 +13,7 @@ module use /appl/local/csc/modulefiles
 Available software:
 
 * Amber
-* Allas (only for the Finnish national system users)
+* [Allas](https://docs.csc.fi/data/Allas/allas_lumi/) (only for the Finnish national system users)
 * CP2K
 * Elmer
 * GDAL


### PR DESCRIPTION
@rkronberg , should we add the link here in LUMI docs? I'm not sure what would be the best way to set the link/page in https://docs.csc.fi/apps/by_system/#lumi, such that it works with the current settings of how the page in CSC docs is created