### PR TITLE
Update kl/modules easybuild 23.09

### DIFF
--- a/docs/runjobs/lumi_env/Lmod_modules.md
+++ b/docs/runjobs/lumi_env/Lmod_modules.md
@@ -135,18 +135,19 @@ It has three levels, producing different outputs:
           utility
 
          Versions:
+            gnuplot/5.4.3-cpeAMD-22.08
             gnuplot/5.4.3-cpeAOCC-21.12
-            gnuplot/5.4.3-cpeAOCC-22.06
+            gnuplot/5.4.3-cpeAOCC-22.08
             gnuplot/5.4.3-cpeCray-21.12
             gnuplot/5.4.3-cpeCray-22.06
-            gnuplot/5.4.3-cpeGNU-21.12
-            gnuplot/5.4.3-cpeGNU-22.06
+            gnuplot/5.4.3-cpeCray-22.08
+            ...
     ```
 
-    so even though the capitalisation of the name was wrong, it can tell us that
-    there are six versions of gnuplot. The `cpeGNU-22.06` and `cpeCray-22.06`
+    (abbreviated output) so even though the capitalisation of the name was wrong, it can tell us that
+    there are multiple versions of gnuplot. The `cpeAOCC-22.08` and `cpeCray-22.06`
     tell that the difference is the compiler that was used to install gnuplot,
-    being the GNU compiler (PrgEnv-gnu) and the Cray compiler (PrgEnv-cray),
+    being the AMD AOCC compiler (PrgEnv-aocc) and the Cray compiler (PrgEnv-cray),
     respectively. This is somewhat important as it is risky to combine modules
     compiled with different compilers.
 
@@ -165,13 +166,17 @@ It has three levels, producing different outputs:
          Versions:
             CMake/3.22.2 (E)
             CMake/3.23.2 (E)
+            CMake/3.24.0 (E)
+            CMake/3.25.2 (E)
+            CMake/3.27.7 (E)
 
     Names marked by a trailing (E) are extensions provided by 
     another module.
     ```
 
-    This tells that there is no `CMake` module on the system but that two
-    versions of `CMake` (3.22.2 and 3.23.2) are available on the system as
+    This tells that there is no `CMake` module on the system but that five
+    versions of `CMake` (3.22.2, 3.23.2, 3.24.0, 3.25.2 and 3.27.7) 
+    are available on the system as
     extensions of another module.
 
     !!! info "Information on LUMI software stacks?"
@@ -179,7 +184,8 @@ It has three levels, producing different outputs:
         [Software stacks ][softwarestacks] page.
 
     !!! failure "Known issue"
-        We have run into cases where this list is incomplete. This is caused
+        We have run into cases where the output of the `module spider` 
+        command is incomplete. This is caused
         by the non-standard way in which the Cray programming environment uses
         Lmod and also by the way the software stack needs to be installed
         next to the programming environment rather than integrated with it
@@ -194,64 +200,60 @@ It has three levels, producing different outputs:
     loaded to be able to load the package, e.g.
 
     ```bash
-    $ module spider git/2.37.0
+    $ module spider git/2.42.1
     ```
 
     will return
 
     ```text
     ----------------------------------------------------------------
-      git: git/2.37.0
+      git: git/2.42.1
     ----------------------------------------------------------------
         Description:
           Git is a free and open source distributed version control
           system
 
         You will need to load all module(s) on any one of the lines 
-        below before the "git/2.37.0" module is available to load.
+        below before the "git/2.42.1" module is available to load.
 
           CrayEnv
-          LUMI/22.06  partition/C
-          LUMI/22.06  partition/D
-          LUMI/22.06  partition/EAP
-          LUMI/22.06  partition/G
-          LUMI/22.06  partition/L
+          LUMI/23.09  partition/C
+          LUMI/23.09  partition/G
+          LUMI/23.09  partition/L
     ```
 
     (abbreviated output). Note that it also tells you which other modules need
     to be loaded. You need to choose the line which is appropriate for you and
-    load all modules on that line, not the whole list of in this case 11
+    load all modules on that line, not the whole list of in this case 7
     modules.
 
     This form of `module spider` can also be used to find out how a tool provided
     as an extension by another module can be made available. E.g., in a previous 
-    example we we've seen that `CMake/3.23.2` is available via another module.
+    example we we've seen that `CMake/3.27.7` is available via another module.
     Now
 
     ```bash
-    $ module spider CMake/3.23.2
+    $ module spider CMake/3.27.7
     ```
 
     will return output similar to
 
     ```text
     ----------------------------------------------------------------
-      CMake: CMake/3.23.2 (E)
+      CMake: CMake/3.27.7 (E)
     ----------------------------------------------------------------
         This extension is provided by the following modules. To 
         access the extension you must load one of the following 
         modules. Note that any module names in parentheses show the 
         module location in the software hierarchy.
 
-           buildtools/22.06 (LUMI/22.06 partition/L)
-           buildtools/22.06 (LUMI/22.06 partition/G)
-           buildtools/22.06 (LUMI/22.06 partition/EAP)
-           buildtools/22.06 (LUMI/22.06 partition/D)
-           buildtools/22.06 (LUMI/22.06 partition/C)
-           buildtools/22.06 (CrayEnv)    
+           buildtools/23.09 (LUMI/23.09 partition/L)
+           buildtools/23.09 (LUMI/23.09 partition/G)
+           buildtools/23.09 (LUMI/23.09 partition/C)
+           buildtools/23.09 (CrayEnv)
     ```
-    This tells that `CMake` is provided by the `buildtools/22.06` module and also 
-    indicates six possible combinations of software stack modules that can provide
+    This tells that `CMake` is provided by the `buildtools/23.09` module and also 
+    indicates four possible combinations of software stack modules that can provide
     that module.
 
 
@@ -277,7 +279,7 @@ will return something along the lines of
 The following modules match your search criteria: "mp3"
 ----------------------------------------------------------------
 
-  LAME: LAME/3.100-cpeAOCC-21.12, LAME/3.100-cpeAOCC-22.06, LAME/3.100-cpeCray-21.12, LAME/3.100-cpeCray-22.06, ...
+  LAME: LAME/3.100-cpeAMD-22.08, LAME/3.100-cpeAMD-22.12, ...
     LAME is a high quality MPEG Audio Layer III (mp3) encoder
 ```
 
@@ -285,11 +287,6 @@ though the output will depend on the version of Lmod. This may not be the most
 useful example on a supercomputer, but the library is in fact needed to be able
 to install some other packages even though the sound function is not immediately
 useful.
-
-??? failure "Know issue: Irrelevant output"
-    At the moment of writing of this documentation page, this command actually
-    returns a lot more output, referring to completely irrelevant extensions.
-    This is a bug in the HPE-Cray-provided version of Lmod.
 
 ### module avail
 
@@ -303,7 +300,7 @@ in two ways:
     using only its name.
 
  2. With the name of a module (or a part of the name) it will show all modules
-    that match that (part of) a name. E.g., when `LUMI/22.06` is loaded,
+    that match that (part of) a name. E.g., when `LUMI/22.12` is loaded,
 
     ```bash
     $ module avail gnuplot
@@ -312,9 +309,9 @@ in two ways:
     will show something along the lines of
 
     ```text
-    ----- EasyBuild managed software for software stack LUMI/22.06 on LUMI-L -----
-       gnuplot/5.4.3-cpeAOCC-22.06    gnuplot/5.4.3-cpeGNU-22.06 (D)
-       gnuplot/5.4.3-cpeCray-22.06
+    ----- EasyBuild managed software for software stack LUMI/22.12 on LUMI-L -----
+       gnuplot/5.4.6-cpeAOCC-22.12    gnuplot/5.4.6-cpeGNU-22.12 (D)
+       gnuplot/5.4.6-cpeCray-22.12
 
       Where:
        D:  Default Module
@@ -370,7 +367,7 @@ To load a specific version of the module you need to specify it after the name
 of the module.
 
 ```bash
-$ module load cray-fftw/3.3.10.1
+$ module load cray-fftw/3.3.10.5
 ```
 
 In order to unload a module from your environment, use the `unload` sub-command
@@ -418,25 +415,26 @@ $ module show cray-fftw
 will show
 
 ```text
----------------------------------------------------------------------------------------------------------------------------
-   /opt/cray/pe/lmod/modulefiles/cpu/x86-rome/1.0/cray-fftw/3.3.10.1.lua:
----------------------------------------------------------------------------------------------------------------------------
-help([[Release info:  /opt/cray/pe/fftw/3.3.10.1/release_info]])
+-----------------------------------------------------------------------------------------------------
+   /opt/cray/pe/lmod/modulefiles/cpu/x86-rome/1.0/cray-fftw/3.3.10.5.lua:
+-----------------------------------------------------------------------------------------------------
+help([[Release info:  /opt/cray/pe/fftw/3.3.10.5/release_info]])
 help([[Documentation: `man intro_fftw3`]])
-whatis("FFTW 3.3.10.1 - Fastest Fourier Transform in the West")
-setenv("FFTW_VERSION","3.3.10.1")
-setenv("CRAY_FFTW_VERSION","3.3.10.1")
-setenv("FFTW_ROOT","/opt/cray/pe/fftw/3.3.10.1/x86_rome")
-setenv("FFTW_DIR","/opt/cray/pe/fftw/3.3.10.1/x86_rome/lib")
-setenv("FFTW_INC","/opt/cray/pe/fftw/3.3.10.1/x86_rome/include")
+whatis("FFTW 3.3.10.5 - Fastest Fourier Transform in the West")
+setenv("FFTW_VERSION","3.3.10.5")
+setenv("CRAY_FFTW_VERSION","3.3.10.5")
+setenv("CRAY_FFTW_PREFIX","/opt/cray/pe/fftw/3.3.10.5")
+setenv("FFTW_ROOT","/opt/cray/pe/fftw/3.3.10.5/x86_rome")
+setenv("FFTW_DIR","/opt/cray/pe/fftw/3.3.10.5/x86_rome/lib")
+setenv("FFTW_INC","/opt/cray/pe/fftw/3.3.10.5/x86_rome/include")
 setenv("PE_FFTW_PKGCONFIG_VARIABLES","PE_FFTW_OMP_REQUIRES_@openmp@")
 setenv("PE_FFTW_OMP_REQUIRES"," ")
 setenv("PE_FFTW_OMP_REQUIRES_openmp","_mp")
 setenv("PE_FFTW_PKGCONFIG_LIBS","fftw3f_mpi:libfftw3f_threads:fftw3f:fftw3_mpi:libfftw3_threads:fftw3")
-prepend_path("PKG_CONFIG_PATH","/opt/cray/pe/fftw/3.3.10.1/x86_rome/lib/pkgconfig")
-prepend_path("PATH","/opt/cray/pe/fftw/3.3.10.1/x86_rome/bin")
-prepend_path("MANPATH","/opt/cray/pe/fftw/3.3.10.1/share/man")
-prepend_path("CRAY_LD_LIBRARY_PATH","/opt/cray/pe/fftw/3.3.10.1/x86_rome/lib")
+prepend_path("PKG_CONFIG_PATH","/opt/cray/pe/fftw/3.3.10.5/x86_rome/lib/pkgconfig")
+prepend_path("PATH","/opt/cray/pe/fftw/3.3.10.5/x86_rome/bin")
+prepend_path("MANPATH","/opt/cray/pe/fftw/3.3.10.5/share/man")
+prepend_path("CRAY_LD_LIBRARY_PATH","/opt/cray/pe/fftw/3.3.10.5/x86_rome/lib")
 prepend_path("PE_PKGCONFIG_PRODUCTS","PE_FFTW")
 ```
 
@@ -454,7 +452,8 @@ collection on the login nodes may not give you the right binaries when working
 on one of the types of compute nodes, even though the application modules have
 the same name and version. Also, when saving a collection of modules, the full
 pathname to each of the module files is saved so *the stored collection will
-break if modules have to be moved*.
+break if modules have to be moved*. After a system maintenance interval 
+the stored module configuration is often also broken.
 
 A collection can be created using `save` sub-command.
 
@@ -492,9 +491,9 @@ Lmod supports most Tcl-based module files written for the various versions of
 Environment Modules. It also has its own format for module files, which are Lua
 programs though with a restricted set of Lua functions available. More
 information on developing module files is available in the [Lmod
-documentation][lmod_doc]. Note, however, that that documentation is for the
-latest version of Lmod and not all features may be supported on the version of
-Lmod that is installed on LUMI.
+documentation][lmod_doc]. Even though that documentation is for the latest
+version of Lmod, it is likely very relevant for LUMI as the Lmod version 
+on LUMI is fairly close to the latest version at the moment.
 
 ??? Tip "Tip: Study an existing module file"
     If you want to study an existing module file then `module show <modulename>`

--- a/docs/runjobs/lumi_env/Lmod_modules.md
+++ b/docs/runjobs/lumi_env/Lmod_modules.md
@@ -97,14 +97,6 @@ you can load it. Therefore, the commands for finding modules are so important.
 Some modules may also provide multiple software packages or extensions. Lmod can
 also search for these.
 
-??? failure "Not fully supported on LUMI"
-    The LMOD feature to search for, e.g., Python packages inside a module or
-    other software in a module is not fully exploited on LUMI as the output of
-    some module commands becomes very long and ways to disabling that output do
-    not work properly in the current version of Lmod on LUMI. This is due to two
-    bugs in the version of Lmod that HPE Cray uses, one of which has only been
-    solved in very recent (early 2022) versions.
-
 
 ### module spider
 

--- a/docs/runjobs/lumi_env/Lmod_modules.md
+++ b/docs/runjobs/lumi_env/Lmod_modules.md
@@ -229,7 +229,7 @@ It has three levels, producing different outputs:
 
     This form of `module spider` can also be used to find out how a tool provided
     as an extension by another module can be made available. E.g., in a previous 
-    example we we've seen that `CMake/3.27.7` is available via another module.
+    example we've seen that `CMake/3.27.7` is available via another module.
     Now
 
     ```bash

--- a/docs/runjobs/lumi_env/softwarestacks.md
+++ b/docs/runjobs/lumi_env/softwarestacks.md
@@ -3,9 +3,14 @@
 [easybuild]: https://easybuild.io/
 [eb-in-docs]: ../../software/installing/easybuild.md
 
+[spack-site]: https://spack.readthedocs.io/
+[spack-in-docs]: ../../software/installing/spack.md
+
 [module-environment]: ../../runjobs/lumi_env/Lmod_modules.md
 [containerwrapper]: ../software/installing/container-wrapper.md
 [prgenv]: ../../development/compiling/prgenv.md
+
+[lumi-software-library]: https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs
 
 The LUMI software stacks contain the software that is already installed on
 LUMI. The software stacks are made available through the [LMOD module
@@ -13,28 +18,37 @@ environment][module-environment].
 
 ## Overview
 
-On LUMI, two types of software stacks are currently offered:
+On LUMI, three types of software stacks are currently offered:
 
-- `CrayEnv` offers the Cray Programming Environment (PE) and allows one to use
-   it completely in the way intended by HPE-Cray. The environment also offers a
-   limited selection of additional tools, often in updated versions compared to
-   what SUSE Linux, the basis of the Cray Linux environment, offers. If you
-   need a richer environment, you should use our other software stacks.
+-   `CrayEnv` offers the Cray Programming Environment (PE) and allows one to use
+    it completely in the way intended by HPE-Cray. The environment also offers a
+    limited selection of additional tools, often in updated versions compared to
+    what SUSE Linux, the basis of the Cray Linux environment, offers. If you
+    need a richer environment, you should use our other software stacks.
 
-- `LUMI` is an extensible software stack that is mostly managed through
-   [EasyBuild][easybuild]. (Read more about EasyBuild from LUMI documentation
-   [here][eb-in-docs].) Each version of the LUMI software stack is based on the
-   version of the Cray Programming Environment with the same version number.
+-   `LUMI` is an extensible software stack that is mostly managed through
+    [EasyBuild][easybuild]. You can read more about EasyBuild on LUMI on
+    [the "Easybuild" page in the "Software" section][eb-in-docs]. 
+    Each version of the LUMI software stack is based on the
+    version of the Cray Programming Environment with the same version number.
 
-   A deliberate choice was made to only offer a limited number of software
-   packages in the globally installed stack as the setup of redundancy on LUMI
-   makes it difficult to update the stack in a way that is guaranteed to not
-   affect running jobs and as a large central stack is also hard to manage.
-   However, the EasyBuild setup is such that users can easily install
-   additional software in their home or project directory using EasyBuild build
-   recipes that we provide or they develop, and that software will fully
-   integrate in the central stack (even the corresponding modules will be made
-   available automatically).
+    A deliberate choice was made to only offer a limited number of software
+    packages in the globally installed stack as the setup of redundancy on LUMI
+    makes it difficult to update the stack in a way that is guaranteed to not
+    affect running jobs and as a large central stack is also hard to manage.
+    However, the EasyBuild setup is such that users can easily install
+    additional software in their home or project directory using EasyBuild build
+    recipes that we provide or they develop, and that software will fully
+    integrate in the central stack (even the corresponding modules will be made
+    available automatically).
+
+-   `spack` is an extensible software stack based on the 
+    [Spack package manager][spack-site]. You can read more about Spack on LUMI
+    on [the "Spack" page in the "Software" section][spack-in-docs].
+    Spack is offered "as-is" for users experienced in the use of Spack, but
+    properly pre-configured to use compilers and some libraries already installed
+    on the system. The LUMI User Support Team does not implement new Spack packages or
+    debug build recipes for existing ones.
 
 ## Selecting the software stack
 
@@ -46,41 +60,43 @@ $ module avail
 ... some lines removed here
 
 -------------------------- HPE-Cray PE modules ----------------------------
-   PrgEnv-aocc/8.2.0      (D)      cray-openshmemx/11.5.5
-   PrgEnv-aocc/8.3.3               cray-pals/1.1.8
+   PrgEnv-amd/8.3.3
+   PrgEnv-amd/8.4.0              (D)
+   PrgEnv-aocc/8.3.3
 
 ... some lines removed here
 
 ----------------------------- Software stacks -----------------------------
-   CrayEnv (S)    LUMI/21.12 (S,D)    LUMI/22.06 (S)
+   CrayEnv    (S)      LUMI/23.03  (S)    spack/22.08-2
+   LUMI/22.08 (S,D)    LUMI/23.09  (S)    spack/23.03
+   LUMI/22.12 (S)      spack/22.08        spack/23.03-2 (D)
 
 --------------------- Modify the module display style ---------------------
-   ModuleColour/off        (S)      ModuleLabel/system   (S)
-   ModuleColour/on         (S,D)    ModulePowerUser/LUMI (S)
-   ModuleLabel/label       (S,D)    ModuleStyle/default
-   ModuleLabel/PEhierarchy (S)      ModuleStyle/reset    (D)
+   ModuleColour/off      (S)        ModuleLabel/PEhierarchy (S)
+   ModuleColour/on       (S,D)      ModuleLabel/system      (S)
+   ModuleExtensions/hide (S)        ModulePowerUser/LUMI    (S)
+   ModuleExtensions/show (S,D)      ModuleStyle/default
+   ModuleLabel/label     (S,L,D)    ModuleStyle/reset       (D)
 
 -------------------------- System initialisation --------------------------
-   init-lumi/0.1 (S,L)
+   init-lumi/0.2 (S,L)
 
 ------------------------- Non-PE HPE-Cray modules -------------------------
 
 ... some lines removed here
 
 ------------------- This is a list of module extensions -------------------
-    Autoconf         (E)     GPP   (E)     Yasm     (E)     libtool  (E)
-    Autoconf-archive (E)     M4    (E)     byacc    (E)     make     (E)
-    Automake         (E)     Meson (E)     flex     (E)     patchelf (E)
-    Bison            (E)     NASM  (E)     gperf    (E)     re2c     (E)
-    CMake            (E)     Ninja (E)     help2man (E)     sec      (E)
-    Doxygen          (E)     SCons (E)     htop     (E)     tree     (E)
+    rclone (E)     restic (E)     s3cmd (E)
+
+... some lines removed here
 ```
 
 The first block(s) in the output are the modules available through the default
 software stack.
 
 The *Software stacks* block in the output shows the available software stacks:
-`CrayEnv`, `LUMI/21.12` and `LUMI/22.06` in this example. The `(S)` besides the
+`CrayEnv`, 4 versions of the `LUMI` stack and 
+4 versions of the `spack` stack in this example. The `(S)` besides the
 name shows that these are sticky modules that won't be removed by default by
 ``module purge``. This is done to enable you to quickly clean your environment
 without having to re-initialize from scratch. In the future we may mark some
@@ -89,25 +105,27 @@ a release that we will try to support long-term (ideally two years), but
 currently the system is changing too rapidly (as some of the hardware is new
 and not an evolution of previous hardware) so we cannot guarantee any level of
 longevity for any of the software stacks. In fact, past experience has shown
-that we may have to remove a stack after 6 to 8 months.
+that we may have to remove a stack after a year or so.
 
 The next block, titled *Modify the module display style*, contains several
 modules that can be used to change the way the module tree is displayed:
 
-- `ModuleColour`: these modules can be used to turn the colour on or off in
-   the module display.
-- `ModuleLabel`: change the way the modules are subdivided in blocks and the
-   way those blocks are presented.
-- `ModuleLabel/label` is the default and will collapse related groups
-   of modules in single blocks, including the Cray PE modules.
-- `ModuleLabel/PEhierarchy`: will still use the user-friendly style of
-   labeling but will show the complete hierarchy in the modules of the Cray
-   PE.
-- `ModuleLabel/system`: does not use the user-friendly label texts, but shows
-   the path of the module directory instead.
-- `ModulePowerUser`: will also reveal several hidden modules, most of which
-   are only important to sysadmins or users who really want to do EasyBuild
-   development in a clone of the software stack.
+-   `ModuleColour`: these modules can be used to turn the colour on or off in
+    the module display.
+-   `ModuleLabel`: change the way the modules are subdivided in blocks and the
+    way those blocks are presented.
+-   `ModuleLabel/label` is the default and will collapse related groups
+    of modules in single blocks, including the Cray PE modules.
+-   `ModuleLabel/PEhierarchy`: will still use the user-friendly style of
+    labeling but will show the complete hierarchy in the modules of the Cray
+    PE.
+-   `ModuleLabel/system`: does not use the user-friendly label texts, but shows
+    the path of the module directory instead.
+-   `ModulePowerUser`: will also reveal several hidden modules, most of which
+    are only important to sysadmins or users who really want to do EasyBuild
+    development in a clone of the software stack.
+-   `ModuleExtensions/hide` and `ModuleExtensions/show` are used to hide or show
+    the module extensions at the end of the overview of `module avail`.
 
 ### CrayEnv
 
@@ -136,30 +154,29 @@ The LUMI software stack is activated by loading the desired version of the LUMI
 module, e.g.,
 
 ```bash
-module load LUMI/22.06
+module load LUMI/23.09
 ```
 
 The `LUMI` module will try to detect the node type it is running on and will
 automatically select the software stack for the node type by automatically
-loading a `partition module`. However, that choice can always be overwritten by
-loading another `partition module`, and this can even be done in a single
+loading a `partition` module. However, that choice can always be overwritten by
+loading another `partition` module, and this can even be done in a single
 command, e.g.,
 
 ```bash
-module load LUMI/22.06 partition/L
+module load LUMI/23.09 partition/L
 ```
 
 will load the software stack for the login nodes (which in fact will also work
 on the compute nodes and data analysis and visualization nodes).
 
-??? failure "Only partition/L and partition/C are fully supported"
-    Note that in the initial version of the software stack, only `partition/L`
-    and `partition/C` are supported. Software in `partition/L` can be used on
+??? note "`partition/L` and LUMI-C compute nodes"
+    Software in `partition/L` can be used on
     the compute nodes also and there is even some MPI-based software already
-    installed in that partition. However, from the `LUMI/21.12` stack on,
+    installed in that partition. However, 
     software compiled in `partition/C` may offer better performance on the
-    compute nodes of LUMI-C as that software is not optimized for the specific
-    architecture of the CPUs in those nodes.
+    compute nodes of LUMI-C as software in that partition is specifically
+    optimised for the zen3 "Milan" CPUs in those nodes.
 
     Running MPI programs is not supported on the login nodes, but those modules
     may still contain useful pre- or postprocessing software that can be used
@@ -167,45 +184,50 @@ on the compute nodes and data analysis and visualization nodes).
 
 Once loaded you will be presented with a lot of modules in a flat naming scheme.
 This means that all software available in that version of the LUMI software
-stack will be shown by module avail (except for hidden modules for software that
+stack will be shown by `module avail` (except for hidden modules for software that
 we deem most users may not directly load). However, not any combination of
 modules can be loaded together. In particular, software compiled with different
 programming environments cannot be used together. There are five types of
 modules:
 
-- The module version contains `cpeGNU-yy.mm` (with `yy.mm` the version of the
-   LUMI stack): The package is compiled with the `PrgEnv-gnu` programming
-   environment.
+-   The module version contains `cpeGNU-yy.mm` (with `yy.mm` the version of the
+    LUMI stack): The package is compiled with the `PrgEnv-gnu` programming
+    environment.
 
-- The module version contains `cpeCray-yy.mm`: The package is compiled with
-   the `PrgEnv-cray` programming environment.
+-   The module version contains `cpeCray-yy.mm`: The package is compiled with
+    the `PrgEnv-cray` programming environment.
 
-- The module version contains `cpeAOCC-yy.mm`:  The package is compiled with
-   the `PrgEnv-aocc` programming environment, the AMD compilers for CPU-only
-   work (hence available only on LUMI-C, LUMI-D and the login nodes)
+-   The module version contains `cpeAOCC-yy.mm`:  The package is compiled with
+    the `PrgEnv-aocc` programming environment, the AMD compilers for CPU-only
+    work (hence available only on LUMI-C, LUMI-D and the login nodes)
 
-- The module version contains `cpeAMD-yy.mm`: The package is compiled with
-   the `PrgEnv-AMD` programming environment, the Cray wrapper around the
-   AMD ROCm compilers. This environment will only be offered on LUMI-G.
+-   The module version contains `cpeAMD-yy.mm`: The package is compiled with
+    the `PrgEnv-AMD` programming environment, the Cray wrapper around the
+    AMD ROCm compilers. This environment will only be offered on LUMI-G.
 
-- The name contains neither of those: The package is compiled with the system
-   gcc compiler, something that is only done for software that is
-   not performance-critical like some build tools and workflow tools.
+-   The name contains neither of those: The package is compiled with the system
+    gcc compiler, something that is only done for software that is
+    not performance-critical like some build tools and workflow tools.
 
 In EasyBuild, `cpeGNU`, `cpeCray`, `cpeAOCC` and `cpeAMD` are called toolchains, a set of
 compatible compilers, MPI and mathematical libraries. Software compiled with the
 system compiler is also called software compiled with the system toolchain,
-which is a restricted toolchain that only contains the compiler. Software
+which is a restricted toolchain that only contains the compiler that comes with
+the operating system. Software
 compiled with different `cpe*` toolchains cannot be loaded at the same time but
 can be loaded together with software compiled with the SYSTEM toolchain. The
 module system currently does not protect you against making such mistakes!
 However, software may fail to work properly.
 
 ??? failure "Issue: Missing programming environments"
-    In `LUMI/21.12`, `cpeAMD` (is not yet supported. 
-    In `LUMI/22.06`, `cpeAOCC` and `cpeAMD` are not yet properly
-    installed.
-    Compiling in any `21.08` environment is no longer supported.
+    When we retire a programming environment from the system, the
+    corresponding `LUMI` module may remain available for a while with
+    some tricks under the hood so that software already compiled for that
+    version of the `LUMI` module would mostly still run. However,
+    no new compilations should be done with such a toolchain, and
+    we cannot guarantee that all software will still run (and know
+    for sure that some software will not run anymore due to the way
+    it is linked against libraries).
 
 ## Adding additional software to the LUMI software stack
 
@@ -216,6 +238,12 @@ and no longer needs to be updated). Therefore, the `LUMI` software stack can be
 extended with software installed in the user's space through EasyBuild in a way
 that is 100% compatible with the system stack. That software will be
 automatically visible when loading the `LUMI` module.
+
+The [LUMI Software Library][lumi-software-library] provides an overview of all
+software that is either available pre-installed on the system or can be 
+user-installed via EasyBuild using recipes developed by LUST and partners in the
+LUMI project (and instructions for some software that is unsuitable for installation
+through EasyBuild).
 
 The default location for user-installed software in `$HOME/EasyBuild`. However,
 we advise to install software in the `/project` directory of the project
@@ -228,7 +256,7 @@ export EBU_USER_PREFIX=/project/project_465000000
 ```
 
 It is a good idea to do this in your `.profile` or `.bashrc` file. This will
-enable the ``LUMI`` modules to also find the software installed in that directory.
+enable the `LUMI` modules to also find the software installed in that directory.
 
 Loading the `EasyBuild-user` module will enable installing software with
 EasyBuild for the current version of the `LUMI` software stack and current node

--- a/docs/software/installing/easybuild.md
+++ b/docs/software/installing/easybuild.md
@@ -13,8 +13,9 @@ stack is kept as compact as possible to ease maintenance and to avoid user
 confusion. E.g., packages for which users request special customisations will
 never be installed in the central software stack. Moreover, due to the
 technical implementation of a software stack on a system the size of LUMI,
-installing software can be disruptive, so new software is mostly made available
-during maintenance intervals.
+some software maintenance operations in the stack can be disruptive and
+only be done during system maintenance intervals, making maintenance 
+difficult.
 
 This, however, does not mean that you may have to wait for weeks before you can
 get the software you need for your project on LUMI. We have made it very easy to
@@ -50,16 +51,16 @@ An EasyBuild build recipe is a file with a name that consists of different
 components and ends with '.eb'. Consider, e.g., a build recipe for the software GROMACS:
 
 ```text
-GROMACS-2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU.eb
+GROMACS-2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU.eb
 ```
 
 The first part of the name, `GROMACS`, is the name of the package. The second
-part of the name, `2021.4` is the version of GROMACS, in this case the
+part of the name, `2022.5` is the version of GROMACS, in this case the
 2021.4 release. 
 
-The next part, `cpeGNU-22.08`, denotes the so-called *toolchain*
+The next part, `cpeGNU-23.09`, denotes the so-called *toolchain*
 used for the build. Each toolchain corresponds to a particular HPE Cray Programming
-Environment, and the number (`22.08`in this example) denotes the version of this
+Environment, and the number (`23.09`in this example) denotes the version of this
 programming environment. The various EasyBuild toolchains on LUMI are:
 
 | EasyBuild toolchain | HPE Cray PE                                                    |
@@ -75,9 +76,9 @@ just the version in the file name that should match but the version of the
 toolchain that is used in the recipe file.) 
 
 The last part of the name,
-`-PLUMED-2.7.4-CPU`, is called the version suffix. Version suffixes are
+`-PLUMED-2.9.0-noPython-CPU`, is called the version suffix. Version suffixes are
 typically used to distinguish different builds of the same version of the
-package. In this case, it indicates that it is a build of the 2021.4 version
+package. In this case, it indicates that it is a build of the 2022.5 version
 purely for CPU and also includes PLUMED as we have also builds without PLUMED
 (which is not compatible with every GROMACS version).
 
@@ -164,7 +165,7 @@ loaded. Assume that we want to install software in the `LUMI/22.08` stack, then
 one needs to execute
 
 ``` bash
-$ module load LUMI/22.08
+$ module load LUMI/23.09
 ```
 
 This should also automatically load the right `partition module` for the part
@@ -174,7 +175,9 @@ stacks][softwarestacks] page.
 Though it is technically possible to cross-compile software for a different
 partition, it may not be without problems as not all install scripts that come
 with software do support cross-compiling and as tests may fail when compiling for
-a CPU with instructions that the host CPU does not support.
+a CPU with instructions that the host CPU does not support. Cross-compiling for 
+the GPU nodes is particularly troublesome as the configuration step will not be
+able to detect the correct GPU type should it try to do so.
 
 ### Step 2: Load EasyBuild
 
@@ -207,25 +210,25 @@ the command line.
 ### Step 3: Install the package
 
 To show how to actually install a package, we continue with our
-`GROMACS-2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU.eb` example.
+`GROMACS-2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU.eb` example.
 
 If all needed EasyBuild recipes are in one of the
 repositories, all you need to do to install the
 package is to run
 
 ```bash
-$ eb GROMACS-2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU.eb -r
+$ eb GROMACS-2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU.eb -r
 ```
 
 The `-r` tells EasyBuild to also install dependencies that may not yet be
 installed.
 
-If the `GROMACS-2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU.eb` would not have been
+If the `GROMACS-2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU.eb` would not have been
 in a repository, but in the current directory or one of its subdirectories,
 you could use 
 
 ```bash
-$ eb GROMACS-2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU.eb -r .
+$ eb GROMACS-2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU.eb -r .
 ```
 
 The only difference is the dot added to the `-r` flag. This adds the current directory to
@@ -240,7 +243,7 @@ package (which may be very useful if building right away fails).
 If you now type `module avail` you should see the
 
 ```text
-GROMACS/2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU
+GROMACS/2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU
 ```
 
 module in the list. Note the relation between the name of the EasyBuild recipe
@@ -249,14 +252,14 @@ the EasyBuild recipe follows the EasyBuild guidelines for naming. If the
 guidelines are not followed and if EasyBuild needs to install this module as a
 dependency of another package, EasyBuild will fail to locate the build recipe.
 
-The `GROMACS/2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU` module can now be used just like
+The `GROMACS/2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU` module can now be used just like
 any other module on the system. To *use* the GROMACS module you don't need to load `EasyBuild-user`.
 That was only required for *installing* the package. 
 All you need to do to use the GROMACS module that we just installed, is 
 
 ```bash
-module load LUMI/22.08
-module load GROMACS/2021.4-cpeGNU-22.08-PLUMED-2.7.4-CPU
+module load LUMI/23.09
+module load GROMACS/2022.5-cpeGNU-23.09-PLUMED-2.9.0-noPython-CPU
 ```
 
 (i.e., loading the software stack in which we installed GROMACS and the GROMACS module that 
@@ -340,7 +343,7 @@ or `module spider`).
 
         In the example above, if the installation commands
         were executed on the login node, the software would have been installed in `partition/L`,
-        but if we then do a `module load LUMI/22.08` on the compute nodes, `partition/C` would have been
+        but if we then do a `module load LUMI/23.09` on the compute nodes, `partition/C` would have been
         selected. To get a GROMACS version in `partition/C` that EasyBuild would build with compiler settings
         that are specific for the processors in the compute nodes, either do the compilation on a compute node
         or use *cross-compiling* by loading `partition/C` after loading `LUMI/22.08` in step 1 above.
@@ -455,6 +458,8 @@ recipes, we suggest the following sources of information:
       on LUMI, with correct dependency versions etc.
     - [LUMI EasyBuild container installation recipes GitHub repository](https://github.com/Lumi-supercomputer/LUMI-EasyBuild-containers)
       contains the recipes that are used to ease access to the containers that are in `/appl/local/containers`.
+    - But a more user-friendly overview of all those recipes is available in the
+      [LUMI Software Library][software-library].
 - Other EasyBuild recipes for the Cray Programming Environment
     - [CSCS GitHub repository](https://github.com/eth-cscs/production).
       Most of the recipes are for Piz Daint which uses slightly different toolchains.


### PR DESCRIPTION
Update to bring the pages about modules, the software stacks and EasyBuild in line with the state of the system after the October 2023 update.