### PR TITLE
Update lumif.md

### DIFF
--- a/docs/storage/parallel-filesystems/lumif.md
+++ b/docs/storage/parallel-filesystems/lumif.md
@@ -5,8 +5,8 @@
 # Flash storage - LUMI-F
 
 The LUMI-F hardware partition provides a Lustre file system with a storage
-capacity of 8 PB and an aggregate bandwidth of 1 740 GB/s. It is composed of 2
-MDSs (metadata servers) and 58 Object Storage Targets (OSTs). Solid state
+capacity of 8.5 PB and an aggregate bandwidth of 2 160 GB/s. It is composed of 4
+MDSs (metadata servers) and 72 Object Storage Targets (OSTs). Solid state
 drives (SSDs) are used in LUMI-F.
 
 Before using LUMI-F, users should familiarize themselves with the performance


### PR DESCRIPTION
lfd df # this shows that we indeed have 72OSTs and 4MDT

lfs df | grep 'lustref1-OST' | cut -d\  -f2 # this sums up to 9374476775600 bytes which is 8.52603 PiB