### PR TITLE
Update info rclone remote endpoints

### DIFF
--- a/docs/storage/lumio/index.md
+++ b/docs/storage/lumio/index.md
@@ -85,14 +85,14 @@ The most common commands for `s3cmd` and `rclone` to
 
 ### rclone
 
-For `rclone`, the LUMI-O configuration provides two remotes endpoints: 
+For `rclone`, the LUMI-O configuration provides two kinds of remotes endpoints: 
 
-- **lumi-o**: The private endpoint. The buckets and objects uploaded to this
+- **lumi-<project_number>-private**: A private endpoint. The buckets and objects uploaded to this
               endpoint will not be publicly accessible.
-- **lumi-pub**: The public endpoint. The buckets and objects uploaded to this
+- **lumi-<project_number>-public**: A public endpoint. The buckets and objects uploaded to this
                 endpoint will publicly accessible using the URL:
                 ```
-                https://<project-number>.lumidata.eu/<bucket_name>`
+                https://<project_number>.lumidata.eu/<bucket_name>`
                 ```
                 Be careful to not upload data that cannot be public to this
                 endpoint.

--- a/docs/storage/lumio/index.md
+++ b/docs/storage/lumio/index.md
@@ -85,11 +85,11 @@ The most common commands for `s3cmd` and `rclone` to
 
 ### rclone
 
-For `rclone`, the LUMI-O configuration provides two kinds of remotes endpoints: 
+For `rclone`, the LUMI-O configuration provides two kinds of remote endpoints: 
 
-- **lumi-<project_number>-private**: A private endpoint. The buckets and objects uploaded to this
+- **lumi-\<project_number\>-private**: A private endpoint. The buckets and objects uploaded to this
               endpoint will not be publicly accessible.
-- **lumi-<project_number>-public**: A public endpoint. The buckets and objects uploaded to this
+- **lumi-\<project_number\>-public**: A public endpoint. The buckets and objects uploaded to this
                 endpoint will publicly accessible using the URL:
                 ```
                 https://<project_number>.lumidata.eu/<bucket_name>`

--- a/docs/storage/lumio/index.md
+++ b/docs/storage/lumio/index.md
@@ -87,9 +87,9 @@ The most common commands for `s3cmd` and `rclone` to
 
 For `rclone`, the LUMI-O configuration provides two kinds of remote endpoints: 
 
-- **lumi-\<project_number\>-private**: A private endpoint. The buckets and objects uploaded to this
+- **lumi-<project_number\>-private**: A private endpoint. The buckets and objects uploaded to this
               endpoint will not be publicly accessible.
-- **lumi-\<project_number\>-public**: A public endpoint. The buckets and objects uploaded to this
+- **lumi-<project_number\>-public**: A public endpoint. The buckets and objects uploaded to this
                 endpoint will publicly accessible using the URL:
                 ```
                 https://<project_number>.lumidata.eu/<bucket_name>`

--- a/docs/storage/lumio/index.md
+++ b/docs/storage/lumio/index.md
@@ -90,7 +90,7 @@ For `rclone`, the LUMI-O configuration provides two kinds of remote endpoints:
 - **lumi-<project_number\>-private**: A private endpoint. The buckets and objects uploaded to this
               endpoint will not be publicly accessible.
 - **lumi-<project_number\>-public**: A public endpoint. The buckets and objects uploaded to this
-                endpoint will publicly accessible using the URL:
+                endpoint will be publicly accessible using the URL:
                 ```
                 https://<project_number>.lumidata.eu/<bucket_name>`
                 ```


### PR DESCRIPTION
Remote endpoints for rclone referred to the old syntax (that is still there with the old version of lumio module, but no more with the latest and default module).