### PR TITLE
Update lumio as expandable

### DIFF
--- a/docs/storage/index.md
+++ b/docs/storage/index.md
@@ -100,9 +100,9 @@ areas.
 | **Project<br>scratch**    | 50 TB | 2000k     | Yes,<br> up to 500TB  | Project lifetime* | 1x              |
 | **Project<br>flash**       |  2 TB | 1000k     | Yes,<br> up to 100TB  | Project lifetime* | 3x             |
 
-|                    | Quota  | Max<br>buckets | Max<br>objects<br>per bucket     | Retention           | Billing<br>rate |
-|--------------------|--------|----------------|----------------------------------|---------------------|-----------------|
-| **Object storage** | 150 TB | 1000           | 500 000                          | project lifetime    | 0.25x            |
+|                    | Quota  | Max objects                     |   Expandable          | Retention         | Billing<br>rate |
+|--------------------|--------|---------------------------------|-----------------------|-------------------|-----------------|
+| **Object storage** | 150 TB | 500M <nobr>(500k/bucket)</nobr> | Yes,<br> up to 2.1 PB | project lifetime  | 0.25x           |
 
 Note that, except for the user home directory, data storage is allocated per
 project. When a storage space is marked as expandable, it means that you can


### PR DESCRIPTION
Updating lumi-o to be expandable until 2.1 PB.

So that the table fits on the page, I modified the buckets/objects columns. I think the way I've presented it now is the best option, but let me know if you come up with something better (such that more columns are not needed..) This can be better clarified on the LUMI-O pages (update in progress)