### PR TITLE
Add `-n 1` option for slurm overlap steps

### DIFF
--- a/docs/runjobs/scheduled-jobs/interactive.md
+++ b/docs/runjobs/scheduled-jobs/interactive.md
@@ -62,7 +62,7 @@ This starts a shell where you can run any command on the first allocated node
 in a specific job:
 
 ```bash
-$ srun --overlap --pty --jobid=<jobid> $SHELL
+$ srun -n 1 --overlap --pty --jobid=<jobid> $SHELL
 ```
 
 By default, you will be connected to the master node of your job which is the 
@@ -105,6 +105,6 @@ $ sacct --noheader -X -P -oNodeList --jobs=<jobid>
     node you try to access:
     
     ```bash
-    srun --overlap --pty --jobid=<jobid> --gpus=<numgpus> $SHELL
+    srun -n 1 --overlap --pty --jobid=<jobid> --gpus=<numgpus> $SHELL
     ```
 


### PR DESCRIPTION
Interactive access by attaching to already existing job allocation with `srun --overlap` can lead to `error-configuring-interconnect` issue when running over multiple nodes. To avoid such problems attaching single task with `-n 1` option is adviced.