### PR TITLE
Update external url for Cray debugging tools (valgrind4hpc) 

### DIFF
--- a/docs/development/debugging/valgrind4hpc.md
+++ b/docs/development/debugging/valgrind4hpc.md
@@ -8,6 +8,7 @@ Memory debugging is the process of tracking bugs related to the allocation and
 deallocation of dynamic memory. This page will start with a short introduction
 on how to use Valgrind for this purpose. Then, we present how to use it for a
 parallel code.
+See also the Cray documentation page about [Cray Debugging Support Tools](https://cpe.ext.hpe.com/docs/latest/debugging-tools/index.html)
 
 ## Valgrind
 

--- a/docs/development/debugging/valgrind4hpc.md
+++ b/docs/development/debugging/valgrind4hpc.md
@@ -8,7 +8,6 @@ Memory debugging is the process of tracking bugs related to the allocation and
 deallocation of dynamic memory. This page will start with a short introduction
 on how to use Valgrind for this purpose. Then, we present how to use it for a
 parallel code.
-See also the Cray documentation page about [debugging tools in Cray Programming Environment](https://cpe.ext.hpe.com/docs/#debugging-tools). 
 
 ## Valgrind
 
@@ -78,6 +77,7 @@ $ valgrind4hpc <valgrind4hpc options> <program-name> -- arg1 arg2
 ```
 
 If your application does not take arguments, the `--` at the end is optional.
+
 The table below summarizes the basic options that you can use with Valgrind4hpc.
 
 | Option                        | Description
@@ -85,7 +85,6 @@ The table below summarizes the basic options that you can use with Valgrind4hpc.
 | `--num-ranks=<num ranks>`     | Specify the number of ranks to run             |
 | `--launcher-args=<arguments>` | Arguments to the application launcher (`srun`) |
 | `--valgrind-args=<arguments>` | Specify Valgrind arguments                     |
-| `--from-ranks=<ranks>`        | Only show Valgrind output from certain ranks   |
 
 For example, to run your application with rank 16 on two nodes, the command will be
 


### PR DESCRIPTION
I am removing unsupported option from the table and outdated url to the HPE documentation I am not able to find update for. 