### PR TITLE
Update new info of LUMI-O key lifetime

### DIFF
--- a/docs/storage/lumio/auth-lumidata-eu.md
+++ b/docs/storage/lumio/auth-lumidata-eu.md
@@ -126,12 +126,7 @@ provides the necessary "Access key" and "Secret key". You can also see the key
 description, which project said key is related to, owner of the key and finally
 Creation and Expiry dates.
 
-From this side menu, it is also possible to extend the duration of the key.
-
-!!! info
-	When you initially create the key, the initial allowed maximum lifetime is 168h = 7 days.
-	This can then be extended by one hour for every hour from key creation,
-    i.e., you are always able to extend the duration of the key to now + 7 days. Default lifetime of the key is 24 hours.
+From this side menu, it is also possible to extend the duration of the key. When you create a new key, the maximum initial lifetime that can be set is 1 year.
 
 It's also possible to download a configuration template for different object storage clients like
 shell, boto3, rclone, s3cmd and aws. After selecting the desired object storage client and clicking "Generate" opens the output in a new browser tab.


### PR DESCRIPTION
Removing the info box because it's maybe not necessary now, and adding a sentence about max initial lifetime of 1 year for a new key.