### PR TITLE
fixes lumio-bucketnames used in examples

### DIFF
--- a/docs/runjobs/webui/index.md
+++ b/docs/runjobs/webui/index.md
@@ -82,7 +82,7 @@ The Cloud storage configuration app will configure a private remote,
 number>-public`, if you have enabled the option. Note that files uploaded to
 the public remote will be publicly accessible on the URL:
 ```
-https://<project-number>.lumidata.eu/<bucket_name>
+https://<project-number>.lumidata.eu/<bucket-name>
 ```
 
 Only shortcuts to the project storage spaces in LUMI-O that have valid

--- a/docs/storage/lumio/advanced.md
+++ b/docs/storage/lumio/advanced.md
@@ -38,13 +38,13 @@ You can generate a presigned url using e.g. s3cmd:
 For example command:
 
 ```bash
-s3cmd signurl s3://<bucket_name>/<object_name> +3600
+s3cmd signurl s3://<bucket-name>/<object-name> +3600
 ```
 
 generates an URL that remains valid for 3600 s (1h). To give access until a specific date, it needs to be expressed in Unix epoch time:
 
 ```bash
-s3cmd signurl s3://<bucket_name>/<object_name> <unix_epoch_time>
+s3cmd signurl s3://<bucket-name>/<object-name> <unix-epoch-time>
 ```
 
 To get the required unix epoch time, it's possible to use online calculators. 
@@ -52,7 +52,7 @@ To get the required unix epoch time, it's possible to use online calculators.
 You can also define the expiration time of the link by adding the desired duration to the current time:
 
 ```
-s3cmd signurl s3://<bucket_name>/<object_name> $(echo "`date +%s` + 3600 * <nbr_of_hours>" | bc)
+s3cmd signurl s3://<bucket-name>/<object-name> $(echo "`date +%s` + 3600 * <nbr_of_hours>" | bc)
 ```
 
 Irregardless of the set expiry time, presigned urls will become invalid when
@@ -61,7 +61,7 @@ the access key used for the signing expires.
 It's also possible to use e.g. an `aws` command to create a presigned URL:
 
 ```bash
-aws s3 presign s3://<bucket_name>/<object_name> --expires-in <seconds>
+aws s3 presign s3://<bucket-name>/<object-name> --expires-in <seconds>
 ```
 
 ### Writable presigned URLs
@@ -166,15 +166,15 @@ You can apply ACL:s to buckets or individual objects.
 To view existing ACLs of buckets or objects you can use 
 
 ```
-s3cmd info s3://<bucket_name>
-s3cmd info s3://<bucket_name>/<object_name>
+s3cmd info s3://<bucket-name>
+s3cmd info s3://<bucket-name>/<object-name>
 ```
 
 or
 
 ```
-aws s3api get-bucket-acl  --bucket <bucket_name>
-aws s3api get-object-acl  --bucket <bucket_name> --key <object_name> 
+aws s3api get-bucket-acl  --bucket <bucket-name>
+aws s3api get-object-acl  --bucket <bucket-name> --key <object-name> 
 ```
 
 
@@ -189,14 +189,14 @@ _*) For accessing shared content by another project, see [accessing shared bucke
 #### Granting public access
 
 ```bash
-s3cmd setacl --recursive --acl-public s3://<bucket_name>/
+s3cmd setacl --recursive --acl-public s3://<bucket-name>/
 ```
 Would make all the objects in the bucket readable by everyone.
 The corresponding operation using `aws s3api`: 
 
 ```bash
-aws s3api put-bucket-acl  --acl public-read --bucket <bucket_name>
-aws s3api put-object-acl --acl public-read --bucket <bucket_name> --key <object_name> 
+aws s3api put-bucket-acl  --acl public-read --bucket <bucket-name>
+aws s3api put-object-acl --acl public-read --bucket <bucket-name> --key <object_name> 
 ```
 requires setting the acl separately for each object as there is no `--recursive` option.
 
@@ -204,12 +204,12 @@ requires setting the acl separately for each object as there is no `--recursive`
 The commands: 
 
 ```bash
-s3cmd setacl --acl-public s3://<bucket_name>/
+s3cmd setacl --acl-public s3://<bucket-name>/
 ```
 or 
 
 ```bash
-aws s3api put-bucket-acl --acl public-read --bucket <bucket_name> 
+aws s3api put-bucket-acl --acl public-read --bucket <bucket-name> 
 ```
 Would make the bucket but not the object readable for the world &rarr; Only possible to list the objects
 but not download them. The inverse situation where the bucket is not readable but the objects are is
@@ -219,14 +219,14 @@ file/object can be retrieved from the directory/bucket, but it's not possible to
 To remove the public access you would run:
 
 ```bash
-s3cmd setacl --recursive --acl-private s3://<bucket_name>
+s3cmd setacl --recursive --acl-private s3://<bucket-name>
 ```
 
 or 
 
 ```bash
-aws s3api put-bucket-acl  --acl private --bucket <bucket_name>
-aws s3api put-object-acl --acl  private --bucket <bucket_name> --key <object_name> 
+aws s3api put-bucket-acl  --acl private --bucket <bucket-name>
+aws s3api put-object-acl --acl  private --bucket <bucket-name> --key <object-name> 
 ```
 Again `put-object-acl` has to be run separately for each object.
 
@@ -234,16 +234,16 @@ Again `put-object-acl` has to be run separately for each object.
 #### Granting access to a specific project
 
 ```bash
-s3cmd setacl --recursive --acl-grant=read:'<proj_id>$<proj_id>' s3://<bucket_name>/
+s3cmd setacl --recursive --acl-grant=read:'<proj_id>$<proj_id>' s3://<bucket-name>/
 ```
 
-Would grant read access to all objects in the `<bucket_name>` bucket for the `<proj_id>` project. 
+Would grant read access to all objects in the `<bucket-name>` bucket for the `<proj_id>` project. 
 The single quotes are important as otherwise the shell might interpret `$<proj_id>` as an (empty) variable
 The corresponding command for `aws s3api` would be:
 
 ```bash
-aws s3api put-bucket-acl --bucket <bucket_name> --grant-read id='<proj_id>$<proj_id>'
-aws s3api put-object-acl --grant-read id='<proj_id>$<proj_id>' --bucket <bucket_name> --key <object_name> 
+aws s3api put-bucket-acl --bucket <bucket-name> --grant-read id='<proj_id>$<proj_id>'
+aws s3api put-object-acl --grant-read id='<proj_id>$<proj_id>' --bucket <bucket-name> --key <object-name> 
 ```
 
 The public rclone remotes configured by lumio-conf use acl settings to make
@@ -262,7 +262,7 @@ So if you need to "unpublish" or "publish" some data you can use the above comma
 The `aws` cli has a larger selection of acl settings than `s3cmd`, e.g
 
 ```bash
-aws s3api put-bucket-acl --bucket <bucket_name> --acl authenticated-read
+aws s3api put-bucket-acl --bucket <bucket-name> --acl authenticated-read
 ```
 
 Can be used to grant read-only access to **all** authenticated users of LUMI-O.
@@ -281,25 +281,25 @@ See the [s3cmd documentation](https://s3tools.org/usage) and [aws s3api document
 You can apply policies to a bucket using `s3cmd` or `aws` commands:
 
 ```
-s3cmd setpolicy policy.json s3://<bucket_name>/
+s3cmd setpolicy policy.json s3://<bucket-name>/
 ```
 
 or
 
 ```
-aws s3api put-bucket-policy --bucket <bucket_name> --policy file://policy.json
+aws s3api put-bucket-policy --bucket <bucket-name> --policy file://policy.json
 ```
 
 You can list the existing polices on a bucket with:
 
 ```
-s3cmd info s3://<bucket_name>
+s3cmd info s3://<bucket-name>
 ```
 
 or 
 
 ```
-aws s3api get-bucket-policy --bucket <bucket_name>
+aws s3api get-bucket-policy --bucket <bucket-name>
 ```
 
 
@@ -398,7 +398,7 @@ s3cmd delpolicy s3://<bucket>
 or 
 
 ```bash
-aws s3api delete-bucket-policy --bucket <bucket_name>
+aws s3api delete-bucket-policy --bucket <bucket-name>
 ```
 
 

--- a/docs/storage/lumio/clients-general.md
+++ b/docs/storage/lumio/clients-general.md
@@ -23,7 +23,7 @@ The configuration by `lumio` module provides two kinds of remote endpoints for `
 - **lumi-<project_number\>-public**: A public endpoint. The buckets and objects uploaded to this
                 endpoint will be publicly accessible using the URL:
                 ```
-                https://<project_number>.lumidata.eu/<bucket_name>
+                https://<project_number>.lumidata.eu/<bucket-name>
                 ```
                 Be careful to not upload data that cannot be public to this
                 endpoint.

--- a/docs/storage/lumio/upload-download.md
+++ b/docs/storage/lumio/upload-download.md
@@ -4,7 +4,7 @@
 Since all project members are seen as one user in LUMI-O (one project = one account), one can not distinguish what bucket or object has been added by which project member. 
 Especially if you have several members in your project, it is a good idea to name the buckets such that you can easily identify them as yours, like:
 
-"Results_myusername" or "SimulationData_ElliExample"
+"Results-myusername" or "SimulationData-ElliExample"
 
 
 Also, it's good to keep in mind that since all project members have the same rights to the data of the project in LUMI-O, one should remember that the other project members are also able to modify or delete the content that you have added, and this can't be changed or restricted. For important data, it's a good practice in any case to have backup elsewhere, and not only keep one copy in one location. 
@@ -30,10 +30,10 @@ rclone lsd lumi-46XXXXXXX-private:   #Replace 46XXXXXXX with your LUMI project n
 
 The command above lists all the buckets for this LUMI project in LUMI-O. If no one from your project has uploaded content to LUMI-O so far, the output is empty. 
 
-The following command creates a new bucket with the name _mynewbucketname_myusername_ :
+The following command creates a new bucket with the name _mynewbucketname-myusername_ :
 
 ```
-rclone mkdir lumi-46XXXXXXX-private:mynewbucketname_myusername
+rclone mkdir lumi-46XXXXXXX-private:mynewbucketname-myusername
 ```
 
 It's in general a good idea to name a bucket such that you will remember that it's your bucket, especially if there are several members in your project. Also this helps the other members in your project to identify that this bucket is yours. 
@@ -41,19 +41,19 @@ It's in general a good idea to name a bucket such that you will remember that it
 You can download a file (e.g. mydatafile.txt) from LUMI filesystem to this bucket with:
 
 ```
-rclone copy mydatafile.txt lumi-46XXXXXXX-private:mynewbucketname_myusername
+rclone copy mydatafile.txt lumi-46XXXXXXX-private:mynewbucketname-myusername
 ```
 
 To see that your datafile is now an object in your bucket, you can list the objects in the bucket with the command:
 
 ```
-rclone ls lumi-46XXXXXXX-private:mynewbucketname_myusername/   
+rclone ls lumi-46XXXXXXX-private:mynewbucketname-myusername/   
 ```
 
 Downloading data from LUMI-O to LUMI works in a similar manner:
 
 ```
-rclone copy lumi-46XXXXXXX-private:mynewbucketname_myusername/mydatafile.txt .
+rclone copy lumi-46XXXXXXX-private:mynewbucketname-myusername/mydatafile.txt .
 ```
 
 This is not the most clever example, since it just downloads the same datafile back to LUMI. Notice that rclone now overwrites the existing data file in LUMI filesystem. 
@@ -61,7 +61,7 @@ This is not the most clever example, since it just downloads the same datafile b
 To download the data of the object 'mydatafile.txt' to a different file in LUMI filesystem, we can tell rclone to rename it e.g. as `mydatafile2.txt` with the following command (notice that now we need to use the `copyto` option with the command):
 
 ```
-rclone copyto lumi-46XXXXXXX-private:mynewbucketname_myusername/mydatafile.txt ./mydatafile2.txt
+rclone copyto lumi-46XXXXXXX-private:mynewbucketname-myusername/mydatafile.txt ./mydatafile2.txt
 ```
 
 The `copyto` command allows creating a new file with a different name, in which the content of 'mydatafile.txt' object is now downloaded from LUMI-O. 


### PR DESCRIPTION
Fixing the error with lumio bucketnames that was used in some examples. The bucketnames are quite restricted, and can not contain e.g. underscores. (If I remember now correctly, they can only contain lowcase letters, numbers and hyphens.) Will add some notation about this later, but it's most important to fix the examples. 