### PR TITLE
feat: add instructions on how to extend LUMI AIF container.

### DIFF
--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -111,7 +111,7 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF bash -c 'source h5-env/bin/activate && python my-script.py'
 ```
 
-## Build new containers based the on the images
+## Build new containers based on the images
 It is possible to create new containers based on the existing containers. In general, the [instructions to extend singularity images](../../software/containers/singularity.md) can be followed.
 
 !!! Warning "GPU support and communication libraries"

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -116,7 +116,7 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF bash -c 'source h5-env/bin/activate && python my-script.py'
 ```
 
-## Build new containers based the on the above
+## Build new containers based on the above
 It is possible to create new containers based on the existing containers. In general, the [instructions to extend singularity images](../../software/containers/singularity.md) can be followed.
 
 !!! Warning "GPU support and communication libraries"

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -162,10 +162,10 @@ To build a new container the following steps are required:
 
         ```
 
-4. Build the container using the [instructions to extend singularity images](../../software/containers/singularity.md). This is possible either on your [own hardware](../../software/containers/singularity.md#building-containers-on-local-hardware) or directly on [LUMI using PR root](../../software/containers/singularity.md#building-or-extending-containers-with-proot).
+4. Build the container using the [instructions to extend singularity images](../../software/containers/singularity.md). This is possible either on your [own hardware](../../software/containers/singularity.md#building-containers-on-local-hardware) or directly on [LUMI using PRoot](../../software/containers/singularity.md#building-or-extending-containers-with-proot).
 
     !!! Warning "Memory requirements"
-        Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive/#interactive-slurm-jobs) and allocating sufficient memory for it. 
+        Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive.md/#interactive-slurm-jobs) and allocating sufficient memory for it. 
 
     Example:
 

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -15,11 +15,6 @@ and machine learning workloads on the LUMI supercomputer. The environment is des
 the complexity of deploying and maintaining AI/ML software in high-performance computing (HPC)
 setting.
 
-!!! Info "Release of the AI Software Environment by LUMI AI Factory"
-    The AI Software Environment by LUMI AI Factory currently undergoes testing and a full release is planned for end of February 2026.
-
-    You can already start using the AI Software Environment now, but we we will update this page with more information about the AI Software Environment and prepare use examples.
-
 All build artifacts are publicly available. This includes the full recipe,
 Containerfiles, build logs, and the resulting final container images. This
 transparent approach enables full customization for special use cases, reuse
@@ -56,7 +51,7 @@ The GitHub releases in a [public GitHub repository][releases on GitHub] include 
 
 ## Examples for using the container images
 
-This list only includes some examples for using the container images. More examples that use older containers supplied by AMD can be found in the [LUMI AI guide][LUMI AI Guide]. We will update these examples with the AI Software Environment by LUMI AI Factory soon.
+This list only includes some examples for using the container images. More examples can be found in the [LUMI AI guide][LUMI AI Guide]. 
 
 !!! Info "lumi-aif-singularity-bindings module"
     To give LUMI containers access to the Slingshot network for good RCCL and MPI performance and access to the file system of the working directory, some additional bindings are required. As it can be quite cumbersome to set these bindings manually, we provide a module that does this for you. You can load the module with the following commands:

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -50,8 +50,9 @@ For users running AI applications based on PyTorch the containers starting with 
 The container images are available from the following locations:
 
 - LUMI supercomputer in directory: `/appl/local/laifs/containers/`
-- GitHub releases in [public GitHub repository][releases on GitHub]
 - Docker Hub in the [LUMI AI Factory organisation](https://hub.docker.com/u/lumiaifactory)
+
+The GitHub releases in a [public GitHub repository][releases on GitHub] include full details of the provided container images.
 
 ## Examples for using the container images
 

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -42,7 +42,7 @@ The [releases on GitHub][releases on GitHub] also include full details of the in
 
 The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-above). We aim to release containers for jax or other software in the future.
+For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-above). We aim to release containers for jax or other software in the future.
 
 
 ## Access to container images
@@ -115,7 +115,7 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF bash -c 'source h5-env/bin/activate && python my-script.py'
 ```
 
-## Build new containers based the above
+## Build new containers based the on the above
 It is possible to create new containers based on the existing containers. In general, the [instructions to extend singularity images](../../software/containers/singularity.md) can be followed.
 
 !!! Warning "GPU support and communication libraries"

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -1,5 +1,15 @@
 # AI Software Environment
 
+[releases on GitHub]: https://github.com/lumi-ai-factory/laifs-container-recipes/releases
+[LUMI AI Guide]: https://github.com/Lumi-supercomputer/LUMI-AI-Guide
+
+
+[singularity-def-file]: https://docs.sylabs.io/guides/latest/user-guide/definition_files.html
+[Running containers on LUMI lecture]: https://lumi-supercomputer.github.io/LUMI-training-materials/ai-20240529/extra_05_RunningContainers/
+[LUMI AI workshop material]: https://github.com/Lumi-supercomputer/Getting_Started_with_AI_workshop
+[PyTorch documentation]: https://pytorch.org/docs/stable/index.html
+[CSC's Machine learning guide]: https://docs.csc.fi/support/tutorials/ml-guide/
+
 The AI Software Environment by LUMI AI Factory is a comprehensive, ready-to-use containerised stack for AI
 and machine learning workloads on the LUMI supercomputer. The environment is designed to address
 the complexity of deploying and maintaining AI/ML software in high-performance computing (HPC)
@@ -28,11 +38,11 @@ new major functionality in the following order:
 4. `lumi-multitorch-torch-*`: Adds PyTorch to the MPICH image
 5. `lumi-multitorch-full-*`: Adds selection of AI and ML libraries (e.g., Bitsandbytes, DeepSpeed, Flash Attention, Megatron LM, vLLM) to the PyTorch image
 
-The [releases on GitHub](https://github.com/lumi-ai-factory/laifs-container-recipes/releases) also include full details of the included software of each image.
+The [releases on GitHub][releases on GitHub] also include full details of the included software of each image.
 
-The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub](https://github.com/lumi-ai-factory/laifs-container-recipes/releases).
+The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can build on intermediate containers to customize to their use cases. We aim to release containers for jax or other software in the future.
+For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-above). We aim to release containers for jax or other software in the future.
 
 
 ## Access to container images
@@ -40,12 +50,12 @@ For users running AI applications based on PyTorch the containers starting with 
 The container images are available from the following locations:
 
 - LUMI supercomputer in directory: `/appl/local/laifs/containers/`
-- GitHub releases in [public GitHub repository](https://github.com/lumi-ai-factory/laifs-container-recipes/releases)
+- GitHub releases in [public GitHub repository][releases on GitHub]
 - Docker Hub in the [LUMI AI Factory organisation](https://hub.docker.com/u/lumiaifactory)
 
 ## Examples for using the container images
 
-This list only includes some examples for using the container images. More examples that use older containers supplied by AMD can be found in the [LUMI AI guide](https://github.com/Lumi-supercomputer/LUMI-AI-Guide/). We will update these examples with the AI Software Environment by LUMI AI Factory soon.
+This list only includes some examples for using the container images. More examples that use older containers supplied by AMD can be found in the [LUMI AI guide][LUMI AI Guide]. We will update these examples with the AI Software Environment by LUMI AI Factory soon.
 
 !!! Info "lumi-aif-singularity-bindings module"
     To give LUMI containers access to the Slingshot network for good RCCL and MPI performance and access to the file system of the working directory, some additional bindings are required. As it can be quite cumbersome to set these bindings manually, we provide a module that does this for you. You can load the module with the following commands:
@@ -56,7 +66,7 @@ This list only includes some examples for using the container images. More examp
     module load lumi-aif-singularity-bindings
     ```
 
-    If you prefer to set the bindings manually, we recommend taking a look at the [Running containers on LUMI lecture](https://lumi-supercomputer.github.io/LUMI-training-materials/ai-20240529/extra_05_RunningContainers/) from the [LUMI AI workshop material](https://github.com/Lumi-supercomputer/Getting_Started_with_AI_workshop).
+    If you prefer to set the bindings manually, we recommend taking a look at the [Running containers on LUMI lecture][Running containers on LUMI lecture] from the [LUMI AI workshop material][LUMI AI workshop material].
 
 ### Run PyTorch using the container
 
@@ -76,7 +86,7 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF pip list
 ```
 
-Alternatively, you can have a look at the software bill of materials (SBOM) `.json` file in the [GitHub releases](https://github.com/lumi-ai-factory/laifs-container-recipes/releases) or in the directory of the container on LUMI.
+Alternatively, you can have a look at the software bill of materials (SBOM) `.json` file in the [releases on GitHub][releases on GitHub] or in the directory of the container on LUMI.
 
 ### Add more pip packages to container
 
@@ -105,10 +115,68 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF bash -c 'source h5-env/bin/activate && python my-script.py'
 ```
 
+## Build new containers based the above
+It is possible to create new containers based on the existing containers. In general, the [instructions to extend singularity images](../../software/containers/singularity.md) can be followed.
+
+!!! Warning "GPU support and communication libraries"
+    Note that for some packages installing for GPU or the correct communication libraries might require significant work. We recommend starting with a suitable image that has most of the required software to migitate the risk of that happening.
+
+To build a new container the following steps are required:
+
+1. Check what software you want to install.
+
+    *Note: For small pip packages a [virtual environment](#list-pip-packages-in-container) might be sufficient.*
+
+
+2. Identify the correct base container from the the [releases on GitHub][releases on GitHub].
+
+    Examples:
+
+    - For installing jax start with the `lumi-multitorch-mpich-*` image
+
+    - For installing a system package while requiring PyTorch and vLLM start with the `lumi-multitorch-full-*` image.
+
+3. Create a [Singularity definition file][singularity-def-file].
+
+    Examples:
+
+    - Add pip package like `scikit-learn` to `lumi-multitorch-torch-*`:
+
+        Save the following as `scitkit.def`.
+        ```
+        Bootstrap: docker
+        From: docker.io/lumiaifactory/lumi-multitorch:torch
+
+        %post
+            . /opt/venv/bin/activate
+            pip install scikit-learn
+
+        ```
+
+
+    - Add some system package like `nvtop` to `lumi-multitorch-full-*`:
+
+        Save the following as `nvtop.def`.
+        ```
+        Bootstrap: docker
+        From: docker.io/lumiaifactory/lumi-multitorch:full
+
+        %post
+            apt-get install -y nvtop
+
+        ```
+
+4. Build the container using the [instructions to extend singularity images](../../software/containers/singularity.md). This is possible either on your [own hardware](../../software/containers/singularity.md#building-containers-on-local-hardware) or directly on [LUMI using PR root](../../software/containers/singularity.md#building-or-extending-containers-with-proot).
+
+    !!! Warning "Memory requirements"
+        Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive/#interactive-slurm-jobs) and allocating sufficient memory for it. 
+
+
+5. Check if the package has been installed correctly
 
 
 ## More information
 
-- [LUMI AI Guide](https://github.com/Lumi-supercomputer/LUMI-AI-Guide)
-- [PyTorch documentation](https://pytorch.org/docs/stable/index.html)
-- [CSC's Machine learning guide](https://docs.csc.fi/support/tutorials/ml-guide/)
+- [LUMI AI Guide][LUMI AI Guide]
+- [PyTorch documentation][PyTorch documentation]
+- [CSC's Machine learning guide][CSC's Machine learning guide]

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -42,7 +42,7 @@ The [releases on GitHub][releases on GitHub] also include full details of the in
 
 The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-above). We aim to release containers for jax or other software in the future.
+For users running AI applications based on PyTorch, the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-above).
 
 
 ## Access to container images

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -54,7 +54,7 @@ The GitHub releases in a [public GitHub repository][releases on GitHub] include 
 This list only includes some examples for using the container images. More examples can be found in the [LUMI AI guide][LUMI AI Guide]. 
 
 !!! Info "lumi-aif-singularity-bindings module"
-    To give LUMI containers access to the Slingshot network for good RCCL and MPI performance and access to the file system of the working directory, some additional bindings are required. As it can be quite cumbersome to set these bindings manually, we provide a module that does this for you. You can load the module with the following commands:
+    To give LUMI containers access to the file system of the working directory, some additional bindings are required. As it can be quite cumbersome to set these bindings manually, we provide a module that does this for you. You can load the module with the following commands:
 
     ```
     module purge

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -42,7 +42,7 @@ The [releases on GitHub][releases on GitHub] also include full details of the in
 
 The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-above). We aim to release containers for jax or other software in the future.
+For users running AI applications based on PyTorch the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-images). We aim to release containers for jax or other software in the future.
 
 
 ## Access to container images
@@ -116,7 +116,7 @@ export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124
 singularity run $SIF bash -c 'source h5-env/bin/activate && python my-script.py'
 ```
 
-## Build new containers based the on the above
+## Build new containers based the on the images
 It is possible to create new containers based on the existing containers. In general, the [instructions to extend singularity images](../../software/containers/singularity.md) can be followed.
 
 !!! Warning "GPU support and communication libraries"

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -133,7 +133,7 @@ To build a new container the following steps are required:
 
     Examples:
 
-    - For installing jax start with the `lumi-multitorch-mpich-*` image
+    - For installing an alternative deep learning framework like JAX, start with the `lumi-multitorch-mpich-*` image
 
     - For installing a system package while requiring PyTorch and vLLM start with the `lumi-multitorch-full-*` image.
 

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -37,7 +37,7 @@ The [releases on GitHub][releases on GitHub] also include full details of the in
 
 The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch, the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-images).
+For users running AI applications based on PyTorch, the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-on-the-images).
 
 
 ## Access to container images

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -186,3 +186,4 @@ To build a new container the following steps are required:
 - [LUMI AI Guide][LUMI AI Guide]
 - [PyTorch documentation][PyTorch documentation]
 - [CSC's Machine learning guide][CSC's Machine learning guide]
+- [Singularity in LUMI documentation](../../software/containers/singularity.md)

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -177,7 +177,7 @@ To build a new container the following steps are required:
     - `singularity build nvtop.sif nvtop.def`
 
 
-5. Check if the package has been installed correctly
+5. Check if the package has been installed correctly. It depends on the specific package installed how to do that, but for packages using GPUs it might be worth checking if the GPU is being detected. For packages using multiple nodes it is recommended to verify that all nodes are used by your package.
 
 
 ## More information

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -142,7 +142,7 @@ To build a new container the following steps are required:
 
     - Add pip package like `scikit-learn` to `lumi-multitorch-torch-*`:
 
-        Save the following as `scitkit.def`.
+        Save the following as `scikit.def`.
         ```
         Bootstrap: docker
         From: docker.io/lumiaifactory/lumi-multitorch:torch
@@ -170,6 +170,11 @@ To build a new container the following steps are required:
 
     !!! Warning "Memory requirements"
         Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive/#interactive-slurm-jobs) and allocating sufficient memory for it. 
+
+    Example:
+
+    - `singularity build scikit.sif scikit.def`
+    - `singularity build nvtop.sif nvtop.def`
 
 
 5. Check if the package has been installed correctly

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -42,7 +42,7 @@ The [releases on GitHub][releases on GitHub] also include full details of the in
 
 The name of the container includes a timestamp and version identifier. It is explained in the [releases on GitHub][releases on GitHub].
 
-For users running AI applications based on PyTorch, the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-above).
+For users running AI applications based on PyTorch, the containers starting with `lumi-multitorch-full-*` are most likely the best starting point. Advanced users can [build on intermediate containers to customize to their use cases](#build-new-containers-based-the-on-the-images).
 
 
 ## Access to container images

--- a/docs/software/containers/singularity.md
+++ b/docs/software/containers/singularity.md
@@ -237,14 +237,15 @@ for instructions on running this MPI container on LUMI.
 
 ### Building or extending containers with PRoot
 
-It is possible to create or extend containers on lumi by using the PRoot build procedure provided by Singularity CE. This way of building containers does NOT require any root privileges so it is compatible with the strict security policies adopted on LUMI. It is however not covering all the possible cases, so it may not cover your specific use case. Please look at the [Official SingularityCE docs](https://docs.sylabs.io/guides/3.11/user-guide/build_a_container.html#unprivilged-proot-builds) for the specific details on coverage and usage.
+It is possible to create or extend containers on LUMI by using the PRoot build procedure provided by Singularity CE. This way of building containers does NOT require any root privileges so it is compatible with the strict security policies adopted on LUMI. It is however not covering all the possible cases, so it may not cover your specific use case. Please look at the [Official SingularityCE docs](https://docs.sylabs.io/guides/3.11/user-guide/build_a_container.html#unprivilged-proot-builds) for the specific details on coverage and usage.
 PRoot is provided in LUMI as a module and in its [documentation](https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs/p/PRoot/) you can see various ways of loading it.
 The easiest way is to use
 
 ```bash
 module load CrayEnv
 module load PRoot
-````
+```
+
 Then you need to define a container.def file for your container, for example
 
 ```bash

--- a/docs/software/containers/singularity.md
+++ b/docs/software/containers/singularity.md
@@ -264,7 +264,7 @@ singularity build container.sif container.def
 
 !!! Warning "Singularity Cache Directory"
     Note that singularity by default caches pulled files in your `home` directory.
-    We recommend setting it to another location or using the flag `--disable-cache` as described in the [Singularity documentation][singularity-cache-dir].
+    We recommend setting it to another location or disabling it as described in the [Singularity documentation][singularity-cache-dir].
 
 Note that this is a powerful tool that allows you to build iteratively from an already existing container. For example you could configure your container.def to start from an existing sif file in this way:
 

--- a/docs/software/containers/singularity.md
+++ b/docs/software/containers/singularity.md
@@ -12,6 +12,7 @@
 [osu-benchmark]: https://mvapich.cse.ohio-state.edu/benchmarks/
 [singularityce]: https://docs.sylabs.io/guides/latest/user-guide/
 [singularity-def-file]: https://docs.sylabs.io/guides/latest/user-guide/definition_files.html
+[singularity-cache-dir]: https://docs.sylabs.io/guides/latest/user-guide/build_env.html#cache-folders
 [tykky-cotainr-diff]: https://github.com/DeiC-HPC/cotainr/issues/37
 
 [container-jobs]: ../../runjobs/scheduled-jobs/container-jobs.md
@@ -260,6 +261,10 @@ and create your image with
 ```bash
 singularity build container.sif container.def
 ```
+
+!!! Warning "Singularity Cache Directory"
+    Note that singularity by default caches pulled files in your `home` directory.
+    We recommend setting it to another location or using the flag `--disable-cache` as described in the [Singularity documentation][singularity-cache-dir].
 
 Note that this is a powerful tool that allows you to build iteratively from an already existing container. For example you could configure your container.def to start from an existing sif file in this way:
 


### PR DESCRIPTION
Hi, 

see preview [here for ai-environment](https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/laif-extend-container/laif/software/ai-environment/) and [here for singularity](https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/laif-extend-container/software/containers/singularity/).

- added instructions how to extend LUMI AIF Singularity containers (@mitjasai can you have a look)?
- I fixed two typos in Singularity docs and added the suggestion to be careful about cache_dir being in home by default. I saw that (@evitali-csc) had a look last, so maybe that makes sense that you check. I found out the hard way that it goes to home by default, so I figured we could warn users.

I was told to add @gregordecristoforo or somebody else from LUST AI as a reviewer as well, so here you go.

Best,
Marlon