### PR TITLE
Add page for LUMI AIF agent infrastructure

### DIFF
--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -1,0 +1,63 @@
+# Agent infrastructure
+
+The LUMI AI Factory agent infrastructure offers tools that support the use of AI agents for tasks
+involving LUMI.
+
+## MCP server
+
+The LUMI AI Factory provides a
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server,
+which can be found at <https://lumi-aif-agents.2.rahtiapp.fi/mcp>. The server allows agents to
+query a knowledge base comprised of the following sources:
+
+* LUMI Docs
+* [LUMI AI Guide](https://github.com/Lumi-supercomputer/LUMI-AI-Guide)
+
+### Standalone usage
+
+You can test the server manually using the [FastMCP CLI](https://gofastmcp.com/cli/overview).
+
+```bash
+# Install FastMCP Python package
+pip install fastmcp
+
+# List available tools
+fastmcp list https://lumi-aif-agents.2.rahtiapp.fi/mcp
+
+# Call the retrieve_docs tool with query string "pytorch" and return top 2 matches
+fastmcp call https://lumi-aif-agents.2.rahtiapp.fi/mcp retrieve_docs query=pytorch k=2
+```
+
+### Client integration
+
+MCP servers can be integrated with a variety of platforms. This section provides some examples.
+After completing the integration steps for your platform of choice, you can test the server by
+asking the agent a question about LUMI, such as "how many GPUs are there on LUMI?". The agent
+should find and use the appropriate tool without explicit user instruction.
+
+#### CLI coding assistant (OpenCode)
+
+MCP servers are frequently used for providing additional tools to CLI coding assistants like
+[OpenCode](https://opencode.ai/). Below is an example `opencode.json` config file for
+[adding the server to OpenCode](https://opencode.ai/docs/mcp-servers).
+
+```json
+{
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+        "lumi-aif-server": {
+            "type": "remote",
+            "url": "https://lumi-aif-agents.2.rahtiapp.fi/mcp"
+        }
+    }
+}
+```
+
+#### Web chatbot (Claude)
+
+The server can also be used with web-based chatbots like [Claude](https://claude.ai), whose free
+plan allows connecting one custom MCP server at a time. To add the MCP server to Claude, go to the
+[Connectors submenu](https://claude.ai/settings/connectors) and click the *Add custom connector*
+button. Give the connector a name (such as "LUMI AIF Server") and enter the server's URL in the
+*Remote MCP server URL* field.
+

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -1,21 +1,29 @@
-# Agent infrastructure
+# Infrastructure for AI agents
 
-The LUMI AI Factory agent infrastructure offers tools that support the use of AI agents for tasks
-involving LUMI.
+The LUMI AI Factory develops software infrastructure that supports the use of AI agents for
+LUMI-related tasks.
 
 ## MCP server
 
-The LUMI AI Factory provides a
+The LUMI AI Factory provides a public
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server,
-which can be found at <https://lumi-aif-agents.2.rahtiapp.fi/mcp>. The server allows agents to
-query a knowledge base comprised of the following sources:
+which can be found at <https://lumi-aif-agents.2.rahtiapp.fi/mcp>. The server features a tool
+called `retrieve_docs`, which allows agents to search a regularly-updated knowledge base of LUMI
+documentation. The search functionality is implemented using an embedding model that is run locally
+on the MCP server host.
 
-* LUMI Docs
+Access to this tool allows AI agents to, e.g., answer questions about LUMI with more accuracy and
+write code that takes into account LUMI's particular system architecture and software environment.
+
+The knowledge base is comprised of the following sources:
+
+* LUMI Docs (this site)
 * [LUMI AI Guide](https://github.com/Lumi-supercomputer/LUMI-AI-Guide)
 
-### Standalone usage
+### Test the server
 
-You can test the server manually using the [FastMCP CLI](https://gofastmcp.com/cli/overview).
+To understand how the server works, it is possible to test it manually using, e.g.,
+the [FastMCP CLI](https://gofastmcp.com/cli/overview).
 
 ```bash
 # Install FastMCP Python package
@@ -24,22 +32,23 @@ pip install fastmcp
 # List available tools
 fastmcp list https://lumi-aif-agents.2.rahtiapp.fi/mcp
 
-# Call the retrieve_docs tool with query string "pytorch" and return top 2 matches
-fastmcp call https://lumi-aif-agents.2.rahtiapp.fi/mcp retrieve_docs query=pytorch k=2
+# Call the retrieve_docs tool with query string
+# "how to use pytorch on lumi" and return top 2 matches
+fastmcp call https://lumi-aif-agents.2.rahtiapp.fi/mcp \
+    retrieve_docs 'query=how to use pytorch on lumi' 'k=2'
 ```
 
-### Client integration
+### Connect a client
 
-MCP servers can be integrated with a variety of platforms. This section provides some examples.
-After completing the integration steps for your platform of choice, you can test the server by
-asking the agent a question about LUMI, such as "how many GPUs are there on LUMI?". The agent
-should find and use the appropriate tool without explicit user instruction.
+MCP servers can be used with a variety of platforms, such as IDEs (e.g., VS Code), CLI coding
+assistants (e.g., OpenCode) and web-based chat interfaces (e.g., Claude Web).
 
-#### CLI coding assistant (OpenCode)
+* [Add and manage MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+* [MCP Servers | OpenCode](https://opencode.ai/docs/mcp-servers)
+* [Third party connectors with remote MCP - Claude.ai Documentation](https://claude.com/docs/connectors/custom/remote-mcp)
 
-MCP servers are frequently used for providing additional tools to CLI coding assistants like
-[OpenCode](https://opencode.ai/). Below is an example `opencode.json` config file for
-[adding the server to OpenCode](https://opencode.ai/docs/mcp-servers).
+An example `opencode.json` config file is provided for using the LUMI AIF MCP server in
+OpenCode.
 
 ```json
 {
@@ -52,12 +61,4 @@ MCP servers are frequently used for providing additional tools to CLI coding ass
     }
 }
 ```
-
-#### Web chatbot (Claude)
-
-The server can also be used with web-based chatbots like [Claude](https://claude.ai), whose free
-plan allows connecting one custom MCP server at a time. To add the MCP server to Claude, go to the
-[Connectors submenu](https://claude.ai/settings/connectors) and click the *Add custom connector*
-button. Give the connector a name (such as "LUMI AIF Server") and enter the server's URL in the
-*Remote MCP server URL* field.
 

--- a/docs/laif/software/index.md
+++ b/docs/laif/software/index.md
@@ -10,4 +10,5 @@ preview.
 Currently available tools and software:
 
 * [AI Software Enviroment](./ai-environment.md)
+* [Agent infrastructure](./agent-infrastructure.md)
 * [Containerized Workflows](./workflows.md)

--- a/docs/laif/software/index.md
+++ b/docs/laif/software/index.md
@@ -10,5 +10,5 @@ preview.
 Currently available tools and software:
 
 * [AI Software Enviroment](./ai-environment.md)
-* [Agent infrastructure](./agent-infrastructure.md)
 * [Containerized Workflows](./workflows.md)
+* [Infrastructure for AI agents](./agent-infrastructure.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
     - Software:
       - Overview: laif/software/index.md
       - AI Software Environment: laif/software/ai-environment.md
+      - Agent infrastructure: laif/software/agent-infrastructure.md
       - Containerized Workflows: laif/software/workflows.md
     
  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,8 +181,8 @@ nav:
     - Software:
       - Overview: laif/software/index.md
       - AI Software Environment: laif/software/ai-environment.md
-      - Agent infrastructure: laif/software/agent-infrastructure.md
       - Containerized Workflows: laif/software/workflows.md
+      - Infrastructure for AI agents: laif/software/agent-infrastructure.md
     
  
 theme:


### PR DESCRIPTION
Add a page for LUMI AI Factory agent infrastructure. The page documents the use of the LUMI AIF MCP server. Additional LUMI AIF tools for supporting the use of AI agents will be listed on the same page.