### PR TITLE
Add contributing.MD to project to guide new contributors

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -22,7 +22,7 @@ must use pull requests.
     - from `production` if you are a member of the repository
     - [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) otherwise
  - Create / bring there the content you want to work with. Pay attention to file naming!
- - Make sure the data is 100% correct (language is correct, commands work, style is same as in other articles)
+ - Make sure to check that the language is correct, commands work, and style is same as in other articles.
  - When creating a new article, add it also to the `mkdocs.yml` navigation OR in the `index.md` file in that folder.
  - Make a pull request for your work to be added to `production`
     - Assign one or more reviewers, try to choose someone who knows the _content_.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -27,7 +27,9 @@ must use pull requests.
  - Make a pull request for your work to be added to `production`
     - Assign one or more reviewers, try to choose someone who knows the _content_.
         - Please add a link to the rahtiapp-preview page `https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/<your-branch-name>/rest-of-url/` in the Pull Request description to help reviewer.
-    - Pull requests which do not meet the requirements will not be accepted. Note that you can keep committing to a pull request after it has been submitted.
+    - Not all pull requests or suggestions to LUMI docs are necessarily accepted. 
+    - Be prepared to modify your PR based on reviewer feedback.
+    - Note that you can keep committing to a pull request after it has been submitted.
     - Write meaningful pull request messages, so it is easier for reviewers to do their job.
     - Communicate! Use a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/), if you don't wish the branch to be merged to master (i.e. you want to continue working with it).
  - Once your PR has been accepted, remove the temporary branch (if not deleted automatically at merge)

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,47 @@
+# Contributing
+
+
+## Basic rules for everyone
+
+1. Make a pull request early to enable discussion
+2. Ask for a reviewer and allow sufficient time for reviewing
+3. Merge only after a review
+
+
+## Making changes using pull requests
+
+The lumi-userguide repository uses the `production` as the default
+branch. You can make changes in web gui, command line or desktop application.
+
+`production` branch is protected. You cannot make changes to it directly, but you
+must use pull requests.
+
+
+### Workflow for a pull request
+ - Create your own branch (or work in an already existing branch, if agreed)
+    - from `production` if you are a member of the repository
+    - [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) otherwise
+ - Create / bring there the content you want to work with. Pay attention to file naming!
+ - Make sure the data is 100% correct (language is correct, commands work, style is same as in other articles)
+ - When creating a new article, add it also to the `mkdocs.yml` navigation OR in the `index.md` file in that folder.
+ - Make a pull request for your work to be added to `production`
+    - Assign one or more reviewers, try to choose someone who knows the _content_.
+        - Please add a link to the rahtiapp-preview page `https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/<your-branch-name>/rest-of-url/` in the Pull Request description to help reviewer.
+    - Pull requests which do not meet the requirements will not be accepted. Note that you can keep committing to a pull request after it has been submitted.
+    - Write meaningful pull request messages, so it is easier for reviewers to do their job.
+    - Communicate! Use a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/), if you don't wish the branch to be merged to master (i.e. you want to continue working with it).
+ - Once your PR has been accepted, remove the temporary branch (if not deleted automatically at merge)
+
+
+### Previewing changes
+
+#### Active branches
+
+The GitHub web interface gives a preview but it does not render all syntax used in mkdocs correctly.
+A full preview for ongoing work is available for all branches: <https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin>.
+Note that this means that your changes can be seen by anyone including search-engines and AI web crawler, so remember that if you proposed change is sensitive.
+
+#### Local preview
+
+You can also build the documentation locally. See the [README](README.md) for instructions.
+

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -23,7 +23,7 @@ must use pull requests.
     - [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) otherwise
  - Create / bring there the content you want to work with. Pay attention to file naming!
  - Make sure to check that the language is correct, commands work, and style is same as in other articles.
- - When creating a new article, add it also to the `mkdocs.yml` navigation OR in the `index.md` file in that folder.
+ - When creating a new page, add it also to the `mkdocs.yml` navigation.
  - Make a pull request for your work to be added to `production`
     - Assign one or more reviewers, try to choose someone who knows the _content_.
         - Please add a link to the rahtiapp-preview page `https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/<your-branch-name>/rest-of-url/` in the Pull Request description to help reviewer.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ documentation is themed with mkdocs-material + LUMI customization.
   - [Generate the static site](#generate-the-static-site)
 
 
-## Creating issues
+## Improving the documentation
 
 If you find that anything is wrong, badly written or missing, please
 help us to fix it. We try to make this guide as good as possible. We
 appreciate your help.
 
+You can help by creating issues or contributing directly.
+
+### Creating Issues
 The easiest way to create issues is to go to a page that you want to
 create an issue about, and click 'File a bug report for this article'. More
 general issues can be submitted through GitHubs [Issues tab][2].
@@ -27,6 +30,10 @@ general issues can be submitted through GitHubs [Issues tab][2].
 Creating an Issue requires a GitHub account.
 
 [2]: https://github.com/Lumi-supercomputer/docs/issues
+
+### Contributing
+
+See [CONTRIBUTING.MD](CONTRIBUTING.MD) for instructions on how to contribute to the documentation.
 
 ## Building
 


### PR DESCRIPTION
As discussed and mentioned in #287 

Perhaps, we should explicitly name reviewers? [CSC CONTRIBUTING.md](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) has many more details, but I think we could start with this.