### PR TITLE
feat: add LUMI AI Factory agent environment

### DIFF
--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -37,9 +37,9 @@ agent environment is available in a public [GitHub repository][github repository
 Please ensure you understand the following points before using the agent environment:
 
 - **Data privacy:** OpenCode uses the third-party
-  [OpenCode Zen](https://opencode.ai/docs/zen/) inference endpoint by default, which is hosted by
-  [Anomaly Innovations Inc.](https://anoma.ly/) If you use this endpoint, be aware that any data
-  you enter will be sent to the company hosting it. Consider configuring OpenCode to use a
+  [OpenCode Zen](https://opencode.ai/docs/zen/) model endpoint by default, which is hosted by
+  [Anomaly Innovations Inc.](https://anoma.ly/) If you use models from this endpoint, be aware that
+  any data you enter will be sent to the company hosting it. Consider configuring OpenCode to use a
   different endpoint, for example a [custom endpoint](#using-a-custom-endpoint).
 - **Data security:** Your current working directory (`$PWD`) and any subdirectories are accessible
   inside the environment. Your
@@ -57,8 +57,8 @@ Please ensure you understand the following points before using the agent environ
 
 ### How to use
 
-The default OpenCode Zen endpoint does not require the user to authenticate, but free usage is
-limited. It is recommended to use OpenCode with a [custom endpoint](#using-a-custom-endpoint).
+The default OpenCode Zen model endpoint does not require the user to authenticate, but free usage
+is limited. It is recommended to use OpenCode with a [custom endpoint](#using-a-custom-endpoint).
 
 ```shell
 # Load relevant modules
@@ -102,8 +102,8 @@ OpenCode has the following capabilities and limitations inside the agent environ
 
 ### Using a custom endpoint
 
-You can configure a custom endpoint by creating an `opencode.json` configuration file, e.g., in
-your current working directory. See OpenCode's
+You can configure a custom model endpoint by creating an `opencode.json` configuration file, e.g.,
+in your current working directory. See OpenCode's
 [config precedence order](https://opencode.ai/docs/config/#precedence-order) for more information.
 
 The agent environment container ships with [a default configuration][opencode json].

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -64,29 +64,31 @@ OpenCode has the following capabilities and limitations inside the agent environ
 
 ### How to use
 
-You can try out OpenCode with the default endpoint, but it is recommended to use it with
-[a custom endpoint](#using-a-custom-endpoint).
+The default OpenCode Zen endpoint does not require the user to authenticate, but free usage is
+limited. It is recommended to use OpenCode with a [custom endpoint](#using-a-custom-endpoint).
 
 ```shell
 # Load relevant modules
-ml load Local-LAIF lumi-aif-agents
+module load Local-LAIF lumi-aif-agents
 
 # Start opencode
 #
-# NB! This gives OpenCode access to your current working directory
-# as well as any subdirectories.
+# NB! This gives OpenCode access to your current
+# working directory, as well as any subdirectories.
+#
 opencode
 ```
 
-By default, project directories like `/scratch` and `/projappl` are not available in the container
-environment, so if your current working directory is not under one of them, you need to mount them
-yourself.
+Your home directory, as well as any project directories under, e.g, `/scratch`,
+are not mounted in the container environment by default. If you wish OpenCode to have access to
+directories that are not under your current working directory, you can bind mount them by appending
+them to the `SINGULARITY_BIND` environment variable.
 
 ```shell
-# Bind additional directories (optional)
-export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/project/dir
+# Bind mount additional directories (optional)
+export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/dir1,/path/to/dir2
 
-opencode /path/to/project/dir
+opencode /path/to/dir1
 ```
 
 ### Using a custom endpoint

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -87,13 +87,14 @@ You can find documentation on how to write your own `opencode.json` in the
     other files in that folder) or place the file in your current working directory (`$PWD`).
 
 ### Capabilities
-The opencode application has the following capabilities by default:
 
-- It can read and write to the mounted directories (`$pwd`) and subdirectories by default but it will ask for permission to execute any commands.
-- It has access to the [LUMI AI Factory MCP Server](#mcp-server) to answer questions about LUMI with more accuracy.
-- It can use the following Slurm commands: `sacct`, `sbatch`, `scancel`, `sinfo`, `squeue`, and `srun`. 
-- It uses the following [`Agents.md`][Agents.md] file to provide additional context about the LUMI to the model to improve the performance.
+By default, OpenCode has the following capabilities running inside the agent environment:
 
+- Read and write permissions to mounted directories (but will ask for permission before executing commands)
+- Access to the [LUMI AI Factory MCP Server](#mcp-server) for writing code that takes into account
+  LUMI's computing environment
+- An [`AGENTS.md`][AGENTS.md] file that provides runtime context such as a description of the
+  Lustre file system
 
 ## MCP server
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -17,9 +17,9 @@ and an [MCP server](#mcp-server) that provides agents access to relevant user do
 
 ## Agent environment
 
-The LUMI AI Factory agent environment provides [singularity containers][singularity] to use agents directly on LUMI to assist with the usage of LUMI.
-At the moment we provide a container to use the open-source and terminal-based AI coding agent [OpenCode][opencode website] on LUMI. For more information on OpenCode see also [this blogpost][opencode blogpost] on connecting OpenCode to a vLLM instance running on LUMI.
-You can inspect the source code of the agent environment in [this GitHub repository][github repository].
+The LUMI AI Factory agent environment offers [Singularity containers][singularity] for using agents directly on LUMI to assist with using the system.
+Currently, we provide a container to use the open-source, terminal-based [OpenCode][opencode website] AI coding agent on LUMI. For more information on OpenCode, see the LUMI AI Factory blog post on [connecting OpenCode to a vLLM instance running on LUMI][opencode blogpost].
+The source code of the agent environment is made available in [the LUMI AI Factory agent environment GitHub repository][github repository].
 
 !!! Warning "Responsibility for running AI agents"
     The user is always responsible for the actions of their AI agents. Understand that any command run by your agent is executed under your personal user account. As a LUMI user, you must always follow the [LUMI Terms of Use][terms of use].

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -38,19 +38,19 @@ Please ensure you understand the following points before using the agent environ
 
 - **Data privacy:** OpenCode uses the third-party
   [OpenCode Zen](https://opencode.ai/docs/zen/) model endpoint by default, which is hosted by
-  [Anomaly Innovations Inc.](https://anoma.ly/) If you use models from this endpoint, be aware that
-  any data you enter will be sent to the company hosting it. Consider configuring OpenCode to use a
-  different endpoint, for example a [custom endpoint](#using-a-custom-endpoint).
+  [Anomaly Innovations Inc.](https://anoma.ly/), the company that maintains OpenCode. If you use
+  models from this endpoint, be aware that any data that you enter or is read from your working
+  directory will be sent to the company hosting the endpoint. Consider configuring OpenCode to use
+  a different endpoint, for example a [custom endpoint](#using-a-custom-endpoint).
 - **Data security:** Your current working directory (`$PWD`) and any subdirectories are accessible
   inside the environment. Your
-  [home directory is not](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html#contain-containall),
+  [home directory is not accessible](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html#contain-containall),
   with the exception of
   [certain directories](https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/modules/lumi-aif-agents/1.0.0.lua),
-  where OpenCode looks for configuration files and stores data. The
-  [default configuration file][opencode json]
-  included in the environment enforces prompting the user for
-  [permission to use any tools](https://opencode.ai/docs/tools/), including reading and writing,
-  except for the document retrieval tool offered by the LUMI AIF MCP server.
+  where OpenCode looks for configuration files and stores data.
+- **Tool use**: The [default configuration file][opencode json] included in the environment
+  enforces prompting the user for [permission to use any tools](https://opencode.ai/docs/tools/),
+  including reading and writing, except for the [LUMI AIF MCP server](#mcp-server).
 - **Experimental status:** The agent environment is experimental and may evolve rapidly. It is
   recommended to check the GitHub repository for any changes to agent capabilities and permissions
   before use.
@@ -104,7 +104,7 @@ OpenCode has the following capabilities and limitations inside the agent environ
 
 You can configure a custom model endpoint by creating an `opencode.json` configuration file, e.g.,
 in your current working directory. See OpenCode's
-[config precedence order](https://opencode.ai/docs/config/#precedence-order) for more information.
+[config precedence order](https://opencode.ai/docs/config/#locations) for more information.
 
 The agent environment container ships with [a default configuration][opencode json].
 You can find documentation on how to write your own `opencode.json` in the

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -36,31 +36,24 @@ agent environment is available in a public [GitHub repository][github repository
 
 Please ensure you understand the following points before using the agent environment:
 
-- **Third-party inference endpoint:** By default, OpenCode uses the third-party
-  [OpenCode Zen](https://opencode.ai/docs/zen/) inference endpoint. This endpoint is hosted by the
-  OpenCode developers, so be aware that any data you enter will be sent to an external party.
-  However, you can configure OpenCode to use a different endpoint,
-  [including a custom one](#using-a-custom-endpoint).
-- **File access:** By default, your current working directory (`$PWD`) and all its
-  subdirectories are accessible to the agent. However, the default configuration included in the
-  container ensures that the agent must prompt for your permission to use any tools, including
-  reading and writing. For more information about tool use, see
-  [OpenCode documentation on tools](https://opencode.ai/docs/tools/).
-- **Experimental status:** The agent environment is experimental and may evolve rapidly. Check
-  the GitHub repository for any changes to agent capabilities and permissions.
-
-### Capabilities and limitations
-
-OpenCode has the following capabilities and limitations inside the agent environment:
-
-* Mounted directories can be read and written to, but the default `opencode.json` configuration
-  shipped with the container makes OpenCode ask for permission before executing commands.
-* OpenCode has access to the [LUMI AI Factory MCP Server](#mcp-server) for retrieving context
-  information that helps it write code that takes into account LUMI's computing environment.
-* The [AGENTS.md][AGENTS.md] file that ships with the container provides basic runtime context, such
-  as the limitations of login nodes.
-* Slurm commands are not available inside the container. We are working on implementing this
-  feature in a secure manner.
+- **Data privacy:** OpenCode uses the third-party
+  [OpenCode Zen](https://opencode.ai/docs/zen/) inference endpoint by default, which is hosted by
+  [Anomaly Innovations Inc.](https://anoma.ly/) If you use this endpoint, be aware that any data
+  you enter will be sent to the company hosting it. Consider configuring OpenCode to use a
+  different endpoint, for example a [custom endpoint](#using-a-custom-endpoint).
+- **Data security:** Your current working directory (`$PWD`) and any subdirectories are accessible
+  inside the environment. Your
+  [home directory is not](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html#contain-containall),
+  with the exception of
+  [certain directories](https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/modules/lumi-aif-agents/1.0.0.lua),
+  where OpenCode looks for configuration files and stores data. The
+  [default configuration file][opencode json]
+  included in the environment enforces prompting the user for
+  [permission to use any tools](https://opencode.ai/docs/tools/), including reading and writing,
+  except for the document retrieval tool offered by the LUMI AIF MCP server.
+- **Experimental status:** The agent environment is experimental and may evolve rapidly. It is
+  recommended to check the GitHub repository for any changes to agent capabilities and permissions
+  before use.
 
 ### How to use
 
@@ -90,6 +83,22 @@ export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/dir1,/path/to/dir2
 
 opencode /path/to/dir1
 ```
+
+To find out more about accessing directories inside containers, see the SingularityCE documentation on
+[bind paths and mounts](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html).
+
+### Capabilities and limitations
+
+OpenCode has the following capabilities and limitations inside the agent environment:
+
+* Mounted directories can be read and written to, but the default configuration file
+  shipped with the container enforces prompting for permission before executing any commands.
+* OpenCode has access to the [LUMI AI Factory MCP Server](#mcp-server) for retrieving context
+  information that helps it write code that takes into account LUMI's computing environment.
+* The [AGENTS.md][AGENTS.md] file that ships with the container provides basic runtime context,
+  such as the limitations of login nodes and the Lustre file system.
+* Slurm commands are not available inside the container. We are working on implementing this
+  feature in a secure manner.
 
 ### Using a custom endpoint
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -110,10 +110,11 @@ The agent environment container ships with [a default configuration][opencode js
 You can find documentation on how to write your own `opencode.json` in the
 [OpenCode documentation][opencode documentation config].
 
-!!! Info "Place your `opencode.json` in a mounted folder"
-    The `opencode.json` file needs to be in a folder accessible by OpenCode. You could either
-    explictly mount the folder that contains it (remember that this gives OpenCode also access to
-    other files in that folder) or place the file in your current working directory.
+!!! Info "Store your `opencode.json` in a mounted directory"
+    The `opencode.json` file needs to be in a directory accessible inside the environment. It is
+    recommended to store the file either in the current directory (project-specific) or under
+    `~/.config/opencode/` (global), both of which are mounted in the environment and searched by
+    OpenCode by default.
 
 ## MCP server
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -28,7 +28,7 @@ The source code of the agent environment is made available in [the LUMI AI Facto
 
 ### Must read
 
-Please understand the following points before using the agent environment:
+Please ensure you understand the following points before using the agent environment:
 
 - **Third-party inference endpoint:** By default, OpenCode uses the third-party
   [OpenCode Zen](https://opencode.ai/docs/zen/) inference endpoint. This endpoint is hosted by the

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -73,10 +73,18 @@ opencode /path/to/project/dir
 
 ### Using a custom endpoint
 
-In order to use the model you need to create a `opencode.json` configuration file. You can find the default configuration [`opencode.json` in the agent environment repository][opencode json]. You can find documentation on how to write your own `configuration.json` in the [OpenCode documentation][opencode documentation config].
+You can configure a custom endpoint by creating an `opencode.json` configuration file, e.g., in
+your current working directory. See OpenCode's
+[config precedence order](https://opencode.ai/docs/config/#precedence-order) for more information.
 
-!!! Info "Place your `configuration.json` in a mounted folder"
-    The `configuration.json` needs to be in a folder accessible by OpenCode. You could either explictly mount the folder that contains it (remember that this gives OpenCode also access to other files in that folder) or place the file in your current working directory `$pwd`.
+The agent environment container ships with [a default configuration][opencode json].
+You can find documentation on how to write your own `opencode.json` in the
+[OpenCode documentation][opencode documentation config].
+
+!!! Info "Place your `opencode.json` in a mounted folder"
+    The `opencode.json` file needs to be in a folder accessible by OpenCode. You could either
+    explictly mount the folder that contains it (remember that this gives OpenCode also access to
+    other files in that folder) or place the file in your current working directory (`$PWD`).
 
 ### Capabilities
 The opencode application has the following capabilities by default:

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -3,6 +3,11 @@
 The LUMI AI Factory develops software infrastructure that supports the use of AI agents for
 LUMI-related tasks.
 
+## Agent environment
+
+
+
+
 ## MCP server
 
 The LUMI AI Factory provides a public

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -1,11 +1,73 @@
 # Infrastructure for AI agents
 
+[Agents.md]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/opencode/AGENTS.md
+[github repository]: https://github.com/lumi-ai-factory/laifs-agent-env
+[LUMI AI agent guide]: ./../../development/ai-tools/ai-agent-guide.md
+[opencode blogpost]: https://lumi-supercomputer.eu/connecting-opencode-to-lumi/
+[opencode documentation config]: https://opencode.ai/docs/config/ 
+[opencode json]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/opencode/opencode.json
+[opencode website]: https://opencode.ai
+[singularity]: ./../../software/containers/singularity.md
+[terms of use]: https://lumi-supercomputer.eu/termsandpolicies/
+
 The LUMI AI Factory develops software infrastructure that supports the use of AI agents for
-LUMI-related tasks.
+LUMI-related tasks. At the moment there is a [agent environment](#agent-environment) that allows you to use OpenCode on LUMI
+and an [MCP server](#mcp-server) to provide agents access to LUMI related documentation.
 
 ## Agent environment
 
+The LUMI AI Factory agent environment provides [singularity containers][singularity] to use agents directly on LUMI to assist with the usage of LUMI.
+At the moment we provide a container to use the open-source and terminal-based AI coding agent [OpenCode][opencode website] on LUMI. For more information on OpenCode see also [this blogpost][opencode blogpost] on connecting OpenCode to a vLLM instance running on LUMI.
+You can inspect the source code of the agent environment in [this GitHub repository][github repository].
 
+!!! Warning "Responsibility for running AI agents"
+    The user is always responsible for the actions of their AI agents. Understand that any command run by your agent is executed under your personal user account. As a LUMI user, you must always follow the [LUMI Terms of Use][terms of use].
+
+    Read also the [LUMI AI agent guide][LUMI AI agent guide] and the below [must read section](#must-read).
+
+
+### Must read
+Please understand the following points before using the agent environment:
+
+- **Open endpoint:** The agent environment uses an open endpoint running outside of LUMI by default so it possibly shares your data openly with that external, but you can configure it to use [your own model](#use-with-your-own-model).
+- **Access to your files:** The current working directory `$pwd` and all subdirectories are accessible to the agent environment by default, but you need to grant permission to write to the directory.
+- **Experimental:** The agent environment is experimental and it might change rapidly. Do not rely on its outputs.
+
+### How to use
+
+We recommend using opencode with [your own model](#use-with-your-own-model), but you can try it out with the open endpoint.
+
+```shell
+# Load relevant modules
+ml load Local-LAIF opencode
+
+# Start opencode. ATTENTION! This gives opencode access to your 
+# current working directory $pwd and its subdirectories.
+opencode /path/to/project/dir
+```
+
+You can provide opencode access to more directories. In the following example we give it access to `/path/to/project/dir`.
+
+```shell
+# Bind more directories than $pwd (optional)
+export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/project/dir
+
+opencode /path/to/project/dir
+```
+
+### Use with your own model
+In order to use the model you need to create a `opencode.json` configuration file. You can find the default configuration [`opencode.json` in the agent environment repository][opencode json]. You can find documentation on how to write your own `configuration.json` in the [OpenCode documentation][opencode documentation config].
+
+!!! Info "Place your `configuration.json` in a mounted folder"
+    The `configuration.json` needs to be in a folder accessible by OpenCode. You could either explictly mount the folder that contains it (remember that this gives OpenCode also access to other files in that folder) or place the file in your current working directory `$pwd`.
+
+### Capabilities
+The opencode application has the following capabilities by default:
+
+- It can read and write to the mounted directories (`$pwd`) and subdirectories by default but it will ask for permission to execute any commands.
+- It has access to the [LUMI AI Factory MCP Server](#mcp-server) to answer questions about LUMI with more accuracy.
+- It can use the following Slurm commands: `sacct`, `sbatch`, `scancel`, `sinfo`, `squeue`, and `srun`. 
+- It uses the following [`Agents.md`][Agents.md] file to provide additional context about the LUMI to the model to improve the performance.
 
 
 ## MCP server

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -46,21 +46,26 @@ Please understand the following points before using the agent environment:
 
 ### How to use
 
-We recommend using opencode with [your own model](#use-with-your-own-model), but you can try it out with the open endpoint.
+You can try out OpenCode with the default endpoint, but it is recommended to use it with
+[a custom endpoint](#using-a-custom-endpoint).
 
 ```shell
 # Load relevant modules
-ml load Local-LAIF opencode
+ml load Local-LAIF lumi-aif-agents
 
-# Start opencode. ATTENTION! This gives opencode access to your 
-# current working directory $pwd and its subdirectories.
-opencode /path/to/project/dir
+# Start opencode
+#
+# NB! This gives OpenCode access to your current working directory (`$PWD`)
+# as well as any subdirectories.
+opencode
 ```
 
-You can provide opencode access to more directories. In the following example we give it access to `/path/to/project/dir`.
+By default, project directories like `/scratch` and `/projappl` are not available in the container
+environment, so if your current working directory is not under one of them, you need to mount them
+yourself.
 
 ```shell
-# Bind more directories than $pwd (optional)
+# Bind additional directories (optional)
 export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/project/dir
 
 opencode /path/to/project/dir

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure for AI agents
 
-[Agents.md]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/config/AGENTS.md
+[AGENTS.md]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/config/AGENTS.md
 [github repository]: https://github.com/lumi-ai-factory/laifs-agent-env
 [LUMI AI agent guide]: ./../../development/ai-tools/ai-agent-guide.md
 [opencode blogpost]: https://lumi-supercomputer.eu/connecting-opencode-to-lumi/
@@ -26,7 +26,6 @@ The source code of the agent environment is made available in [the LUMI AI Facto
 
     Read also the [LUMI AI agent guide][LUMI AI agent guide] and the below [must read section](#must-read).
 
-
 ### Must read
 
 Please understand the following points before using the agent environment:
@@ -43,6 +42,19 @@ Please understand the following points before using the agent environment:
   [OpenCode documentation on tools](https://opencode.ai/docs/tools/).
 - **Experimental status:** The agent environment is experimental and may evolve rapidly. Check
   the GitHub repository for any changes to agent capabilities and permissions.
+
+### Capabilities and limitations
+
+OpenCode has the following capabilities and limitations inside the agent environment:
+
+* Mounted directories can be read and written to, but the default `opencode.json` configuration
+  shipped with the container makes OpenCode ask for permission before executing commands.
+* OpenCode has access to the [LUMI AI Factory MCP Server](#mcp-server) for retrieving context
+  information that helps it write code that takes into account LUMI's computing environment.
+* The [AGENTS.md][AGENTS.md] file that ships with the container provides basic runtime context, such
+  as the limitations of login nodes.
+* Slurm commands are not available inside the container. We are working on implementing this
+  feature in a secure manner.
 
 ### How to use
 
@@ -85,16 +97,6 @@ You can find documentation on how to write your own `opencode.json` in the
     The `opencode.json` file needs to be in a folder accessible by OpenCode. You could either
     explictly mount the folder that contains it (remember that this gives OpenCode also access to
     other files in that folder) or place the file in your current working directory (`$PWD`).
-
-### Capabilities
-
-By default, OpenCode has the following capabilities running inside the agent environment:
-
-- Read and write permissions to mounted directories (but will ask for permission before executing commands)
-- Access to the [LUMI AI Factory MCP Server](#mcp-server) for writing code that takes into account
-  LUMI's computing environment
-- An [`AGENTS.md`][AGENTS.md] file that provides runtime context such as a description of the
-  Lustre file system
 
 ## MCP server
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -17,14 +17,21 @@ and an [MCP server](#mcp-server) that provides agents access to relevant user do
 
 ## Agent environment
 
-The LUMI AI Factory agent environment offers [Singularity containers][singularity] for using agents directly on LUMI to assist with using the system.
-Currently, we provide a container to use the open-source, terminal-based [OpenCode][opencode website] AI coding agent on LUMI. For more information on OpenCode, see the LUMI AI Factory blog post on [connecting OpenCode to a vLLM instance running on LUMI][opencode blogpost].
-The source code of the agent environment is made available in [the LUMI AI Factory agent environment GitHub repository][github repository].
+The LUMI AI Factory agent environment offers [Singularity containers][singularity] for using agents
+directly on LUMI to assist with using the system.  Currently, we provide a container to use the
+open-source, terminal-based [OpenCode][opencode website] AI coding agent on LUMI. For more
+information on OpenCode, see the LUMI AI Factory blog post on
+[connecting OpenCode to a vLLM instance running on LUMI][opencode blogpost]. The source code of the
+agent environment is made available in
+[the LUMI AI Factory agent environment GitHub repository][github repository].
 
 !!! Warning "Responsibility for running AI agents"
-    The user is always responsible for the actions of their AI agents. Understand that any command run by your agent is executed under your personal user account. As a LUMI user, you must always follow the [LUMI Terms of Use][terms of use].
+    The user is always responsible for the actions of their AI agents. Understand that any command
+    run by your agent is executed under your personal user account. As a LUMI user, you must always
+    follow the [LUMI Terms of Use][terms of use].
 
-    Read also the [LUMI AI agent guide][LUMI AI agent guide] and the below [must read section](#must-read).
+    Read also the [LUMI AI agent guide][LUMI AI agent guide] and the below
+    [must read section](#must-read).
 
 ### Must read
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -28,11 +28,21 @@ The source code of the agent environment is made available in [the LUMI AI Facto
 
 
 ### Must read
+
 Please understand the following points before using the agent environment:
 
-- **Open endpoint:** The agent environment uses an open endpoint running outside of LUMI by default so it possibly shares your data openly with that external, but you can configure it to use [your own model](#use-with-your-own-model).
-- **Access to your files:** The current working directory `$pwd` and all subdirectories are accessible to the agent environment by default, but you need to grant permission to write to the directory.
-- **Experimental:** The agent environment is experimental and it might change rapidly. Do not rely on its outputs.
+- **Third-party inference endpoint:** By default, OpenCode uses the third-party
+  [OpenCode Zen](https://opencode.ai/docs/zen/) inference endpoint. This endpoint is hosted by the
+  OpenCode developers, so be aware that any data you enter will be sent to an external party.
+  However, you can configure OpenCode to use a different endpoint,
+  [including a custom one](#using-a-custom-endpoint).
+- **File access:** By default, your current working directory (`$PWD`) and all its
+  subdirectories are accessible to the agent. However, the default configuration included in the
+  container ensures that the agent must prompt for your permission to use any tools, including
+  reading and writing. For more information about tool use, see
+  [OpenCode documentation on tools](https://opencode.ai/docs/tools/).
+- **Experimental status:** The agent environment is experimental and may evolve rapidly. Check
+  the GitHub repository for any changes to agent capabilities and permissions.
 
 ### How to use
 
@@ -56,7 +66,8 @@ export SINGULARITY_BIND=$SINGULARITY_BIND,/path/to/project/dir
 opencode /path/to/project/dir
 ```
 
-### Use with your own model
+### Using a custom endpoint
+
 In order to use the model you need to create a `opencode.json` configuration file. You can find the default configuration [`opencode.json` in the agent environment repository][opencode json]. You can find documentation on how to write your own `configuration.json` in the [OpenCode documentation][opencode documentation config].
 
 !!! Info "Place your `configuration.json` in a mounted folder"

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -11,8 +11,9 @@
 [terms of use]: https://lumi-supercomputer.eu/termsandpolicies/
 
 The LUMI AI Factory develops software infrastructure that supports the use of AI agents for
-LUMI-related tasks. At the moment there is a [agent environment](#agent-environment) that allows you to use OpenCode on LUMI
-and an [MCP server](#mcp-server) to provide agents access to LUMI related documentation.
+LUMI-related tasks. The current offering comprises a containerized [agent environment](#agent-environment)
+for using the OpenCode coding agent on LUMI
+and an [MCP server](#mcp-server) that provides agents access to relevant user documentation.
 
 ## Agent environment
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -67,7 +67,7 @@ ml load Local-LAIF lumi-aif-agents
 
 # Start opencode
 #
-# NB! This gives OpenCode access to your current working directory (`$PWD`)
+# NB! This gives OpenCode access to your current working directory
 # as well as any subdirectories.
 opencode
 ```
@@ -96,7 +96,7 @@ You can find documentation on how to write your own `opencode.json` in the
 !!! Info "Place your `opencode.json` in a mounted folder"
     The `opencode.json` file needs to be in a folder accessible by OpenCode. You could either
     explictly mount the folder that contains it (remember that this gives OpenCode also access to
-    other files in that folder) or place the file in your current working directory (`$PWD`).
+    other files in that folder) or place the file in your current working directory.
 
 ## MCP server
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -1,11 +1,11 @@
 # Infrastructure for AI agents
 
-[Agents.md]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/opencode/AGENTS.md
+[Agents.md]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/config/AGENTS.md
 [github repository]: https://github.com/lumi-ai-factory/laifs-agent-env
 [LUMI AI agent guide]: ./../../development/ai-tools/ai-agent-guide.md
 [opencode blogpost]: https://lumi-supercomputer.eu/connecting-opencode-to-lumi/
 [opencode documentation config]: https://opencode.ai/docs/config/ 
-[opencode json]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/opencode/opencode.json
+[opencode json]: https://github.com/lumi-ai-factory/laifs-agent-env/blob/main/config/opencode.json
 [opencode website]: https://opencode.ai
 [singularity]: ./../../software/containers/singularity.md
 [terms of use]: https://lumi-supercomputer.eu/termsandpolicies/

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -17,13 +17,12 @@ and an [MCP server](#mcp-server) that provides agents access to relevant user do
 
 ## Agent environment
 
-The LUMI AI Factory agent environment offers [Singularity containers][singularity] for using agents
-directly on LUMI to assist with using the system.  Currently, we provide a container to use the
-open-source, terminal-based [OpenCode][opencode website] AI coding agent on LUMI. For more
-information on OpenCode, see the LUMI AI Factory blog post on
+The LUMI AI Factory agent environment is a [containerized environment][singularity] for running AI
+coding agents on LUMI in a more secure manner. Currently, we provide a container for using the
+open-source, terminal-based [OpenCode][opencode website] AI coding agent. For more information on
+OpenCode, see the LUMI AI Factory blog post on
 [connecting OpenCode to a vLLM instance running on LUMI][opencode blogpost]. The source code of the
-agent environment is made available in
-[the LUMI AI Factory agent environment GitHub repository][github repository].
+agent environment is available in a public [GitHub repository][github repository].
 
 !!! Warning "Responsibility for running AI agents"
     The user is always responsible for the actions of their AI agents. Understand that any command


### PR DESCRIPTION
The LUMI AI Factory agent environment is a [containerized environment](https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/laif_agent_environment/software/containers/singularity/) for running AI coding agents on LUMI in a more secure manner. Currently, we provide a container for using the open-source, terminal-based [OpenCode](https://opencode.ai/) AI coding agent.

https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/laif_agent_environment/laif/software/agent-infrastructure/

We strongly encourage responsible use by pointing to AI Agent Guide and adding must reads. Also there is message being prompted when loading the module.
