### PR TITLE
Update LUMI web interface docs

### DIFF
--- a/docs/runjobs/webui/interactive-apps.md
+++ b/docs/runjobs/webui/interactive-apps.md
@@ -57,3 +57,15 @@ After the job completes, the reason for job completion will be visible.
 Usually this is due to reaching the time limit of the Slurm job, or manually cancelling the session, but some error messages may also be visible here, with additional details available in the log file linked.
 If you are sending a support ticket regarding your app session, please include the log file.
 ![Interactive app completed](../../assets/images/wwwLumiCardTimeout.png)
+
+## Launching Slurm jobs from interactive applications
+
+Interactive applications will have `SLURM_*` environment variables set, which
+may cause errors when trying to launch additional Slurm jobs from the
+Interactive applications, e.g. `srun: fatal: SLURM_MEM_PER_CPU, SLURM_MEM_PER_GPU, and SLURM_MEM_PER_NODE are mutually exclusive`.
+To submit Slurm jobs, you will first need to clear the conflicting Slurm
+environment variables, for example, in Bash:
+```
+# Unsets all environment variables with a prefix of SLURM_
+unset "${!SLURM_@}"
+```

--- a/docs/runjobs/webui/jupyter.md
+++ b/docs/runjobs/webui/jupyter.md
@@ -19,9 +19,12 @@ In the basic settings, the following settings are available:
 
 - **Python**:
     Currently, the following Python modules are available: `cray-python`,
-    `pytorch`, and `geoconda`. Note that `pytorch` and `geoconda` have limited
-    support available. You can also select _Custom_ to provide a full path to
-    the Python interpreter you want to use.
+    `lumi-multitorch` from the
+    [LUMI AI Factory AI Software Environment](../../../laif/software/ai-environment),
+    `geoconda` and `pytorch`. Note that `pytorch` and `geoconda` have limited
+    support available, and the `pytorch` module from the CSC software stack has
+    been deprecated in favor of `lumi-multitorch`. You can also select _Custom_
+    to provide a full path to the Python interpreter you want to use.
 - **Virtual environment:**
     After enabling the use of virtual environment in the form, you can provide
     a path to your virtual environment. If the provided path does not exist, a


### PR DESCRIPTION
Adds `lumi-multitorch` to the list of modules available in Jupyter, and instructions for launching additional Slurm jobs from the interactive apps.