### PR TITLE
Add note about summer opening hours

### DIFF
--- a/docs/helpdesk/index.md
+++ b/docs/helpdesk/index.md
@@ -60,8 +60,10 @@ The LUMI helpdesk is open every weekday from Monday to Friday except during [Fin
 
 |       | CE(S)T  | EE(S)T  | UTC (Summer)      |
 |-------|---------|---------|-------------------|
-| Start | 8:00 AM | 9:00 AM | 7:00 AM (6:00 AM) |
-| End   | 6:00 PM | 7:00 PM | 5:00 PM (4:00 PM) |
+| Start* | 8:00 AM | 9:00 AM | 7:00 AM (6:00 AM) |
+| End * | 6:00 PM | 7:00 PM | 5:00 PM (4:00 PM) | 
+
+*\*) During the summer vacation season (22nd June – 14th August) the LUMI helpdesk operates with reduced opening hours: 9:00 AM – 4:00 PM CEST / 10:00 AM – 5:00 PM EEST.*
 
 
 <br />


### PR DESCRIPTION
Adding a note about LUMI helpdesk opening hours during summer vacation season to the helpdesk page. 
Already added this on the LUMI web page: https://lumi-supercomputer.eu/user-support/need-help/

If we decide to go back to normal shift schedule earlier, we can remove the mentions of the summer opening hours at that point. 