### PR TITLE
Update requirements and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CSC Service Desk <servicedesk@csc.fi>"
 ENV ROOT_GROUP_DIRS='/var/run /var/log/nginx /var/lib/nginx'
 
 RUN yum -y install epel-release &&\
-    yum -y install nginx python39 python39-pip git httpd-tools && \
+    yum -y install nginx python3.12 python3.12-pip git httpd-tools && \
     yum clean all
 
 RUN chgrp -R root ${ROOT_GROUP_DIRS} &&\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This is what we actually install
 mkdocs==1.6.0
 mkdocs-material==9.5.24
-pymdown-extensions==10.16.1
+pymdown-extensions==10.21.3
 
 # This is dependencies
 Babel==2.15.0
@@ -12,7 +12,7 @@ colorama==0.4.6
 csscompressor==0.9.5
 ghp-import==2.0.2
 htmlmin==0.1.12
-idna==3.7
+idna==3.15
 importlib-metadata==4.8.3
 Jinja2==3.1.6
 jsmin==3.0.1
@@ -29,14 +29,14 @@ packaging==21.3
 paginate==0.5.6
 pathspec==0.12.1
 platformdirs==4.2.2
-Pygments==2.18.0
+Pygments==2.20.0
 pyparsing==3.0.7
 python-dateutil==2.8.2
 PyYAML==6.0.3
 pyyaml_env_tag==0.1
 regex==2024.5.15
-requests==2.32.4
+requests==2.33.0
 six==1.16.0
-urllib3==2.6.3
+urllib3==2.7.0
 watchdog==2.1.7
 zipp==3.19.1


### PR DESCRIPTION
Security updates to requirements.txt. 
When testing with local build, it came up that the python version in Dockerfile was too old for the new versions of `requests` and `urllib3`, so updating that also. 
With these changes the local docker build works.

