### PR TITLE
fix: address typos in LUMI AIF documentation

### DIFF
--- a/docs/laif/data/daas-guide.md
+++ b/docs/laif/data/daas-guide.md
@@ -11,8 +11,7 @@
 [LAIF user support email]: mailto:support@lumi-ai-factory.eu
 [LUMI-O user guide]: ./../../storage/lumio/index.md
 [run jobs]: ./../../runjobs/index.md
-[software]: ./../../storage/index.md
-[software library]: https://lumi-supercomputer.github.io/LUMI-EasyBuild-docs/
+[software]: ./../../software/index.md
 [terms of use]: https://lumi-supercomputer.eu/wp-content/uploads/2026/03/LUMI-General-Terms-of-Use_2026.pdf
 
 ## What is LUMI AIF Dataset as a Service?
@@ -76,7 +75,7 @@ the process.
 ### Searching for datasets
 
 The currently available datasets are listed in the [data catalogue][data catalogue].
-Take a look – you don't need have an account to browse it.
+Take a look – you don't need to have an account to browse it.
 
 You can search for datasets by using e.g.
 
@@ -128,7 +127,7 @@ LUMI AI Factory Dataset as a Service is a way for you to get visibility for your
 LUMI AIF DaaS is not a repository or a preservation service. It does not take away your ownership of data or remove your right to manage access to it. LUMI AIF DaaS facilitates access and findability. Publish your data to increase its impact, discover new use cases, meet compliance requirements, attract collaborators and customers, and participate in cutting‑edge scientific and industrial innovation.
 
 ### What is required of a dataset
-LUMI AI Factory Dataset as a Service offers a curated catalog. This means that every dataset offered has been through a process where its suitability has been evaluated. LUMI AI Factory curation criteria is evolving and it will be presented to data providers during our cooperation. To summarize the criteria, the datasets need to be relevant for AI usage, they need to be AI-ready and the data providers need to agree to provide the data under such a license or agreement that it is possible to use it in AI innovation. If you already have used good data management practices and you have a large dataset with some idea of AI useage, your dataset is most likely good to go.
+LUMI AI Factory Dataset as a Service offers a curated catalog. This means that every dataset offered has been through a process where its suitability has been evaluated. LUMI AI Factory curation criteria is evolving and it will be presented to data providers during our cooperation. To summarize the criteria, the datasets need to be relevant for AI usage, they need to be AI-ready and the data providers need to agree to provide the data under such a license or agreement that it is possible to use it in AI innovation. If you already have used good data management practices and you have a large dataset with some idea of AI usage, your dataset is most likely good to go.
 
 Every data provider needs to accept the Terms of Use of LUMI AI Factory Dataset as a Service. If your data contains personal data, also a record of processing activities should be documented. LUMI AIF DaaS accepts datasets containing personal data and other confidential datasets. Datasets containing special categories of personal data are not currently accepted.
 

--- a/docs/laif/inference/aitta.md
+++ b/docs/laif/inference/aitta.md
@@ -11,7 +11,7 @@
 
 !!! Warning "Restriction of Users during Pilot phase"
     Aitta is currently undergoing a piloting phase before a full public release. Integration with all LUMI authentication providers is incomplete.
-    Therefore only users that can use MyCSC or Haka authentication can currently access the service. Users that need to authenticate via Puhuri, MyAccessID, the European Federation Platform, or others unfortunately cannot access Aitta at the moment. We are hoping resolve this soon.
+    Therefore only users that can use MyCSC or Haka authentication can currently access the service. Users that need to authenticate via Puhuri, MyAccessID, the European Federation Platform, or others unfortunately cannot access Aitta at the moment. We are hoping to resolve this soon.
 
 Aitta is a machine learning inference service that allows you to interact with large open-weight models (i.e., models that are openly available for download e.g. from huggingface.co) directly on the LUMI Supercomputer hardware without dealing with any of the technical details. You just send your inference request to an OpenAI compatible API - Aitta takes care of allocating resources from the supercomputer scheduling system (Slurm), loading the model and forwarding the request to the designated compute node.
 
@@ -42,7 +42,7 @@ Visit the web frontend at [aitta.csc.fi][aitta]. Click the "Log In" button at th
 
 <details><summary>Detailed instructions for the web frontend</summary>
 
-  1. After you have logged in, you will see a page that shows the available models and whether they are currently online or not. If the model is online, it means that is already loaded into GPU memory and ready to respond immediately. Starting a chat with a model marked as offline means you will have to wait a bit while the model is made ready to respond. Click on any model to open a chat view.
+  1. After you have logged in, you will see a page that shows the available models and whether they are currently online or not. If the model is online, it means that it is already loaded into GPU memory and ready to respond immediately. Starting a chat with a model marked as offline means you will have to wait a bit while the model is made ready to respond. Click on any model to open a chat view.
     <figure>
       <img
         src="/assets/images/laifs/aitta/aitta_model_page.png"
@@ -76,9 +76,9 @@ Visit the web frontend at [aitta.csc.fi][aitta]. Click the "Log In" button at th
       <img
         src="/assets/images/laifs/aitta/model_ready_page.png"
         width="1000px"
-        alt='When the model is ready the website displays an empty chat window. The user has typed "Can you explain to me the difference between a laptop and a supercomputer?" in the message input field at the buttom of the page.'
+        alt='When the model is ready the website displays an empty chat window. The user has typed "Can you explain to me the difference between a laptop and a supercomputer?" in the message input field at the bottom of the page.'
       />
-      <figcaption>When the model is ready the website displays an empty chat window. The user has typed "Can you explain to me the difference between a laptop and a supercomputer?" in the message input field at the buttom of the page.</figcaption>
+      <figcaption>When the model is ready the website displays an empty chat window. The user has typed "Can you explain to me the difference between a laptop and a supercomputer?" in the message input field at the bottom of the page.</figcaption>
     </figure>
 
   5. Aitta will forward your message to the model and stream the response back to the web frontend where it will appear in the chat window. Every message has associated buttons which you can use to
@@ -106,12 +106,12 @@ Visit the web frontend at [aitta.csc.fi][aitta]. Click the "Log In" button at th
       <figcaption>Hovering the mouse over the "Models" text at the top of the page shows a list of all models.</figcaption>
     </figure>
 
-  7. When you are done, you can log out via the "Log Out" button at the top right corner or simply leave the page. You do not need to explicitely shut down any model you were using.
+  7. When you are done, you can log out via the "Log Out" button at the top right corner or simply leave the page. You do not need to explicitly shut down any model you were using.
 
 </details>
 ### Limitations
 
-The web frontend is only a basic chat interface with no additional features. The entire chat history is kept in your browser. If you leave the page, the conversation is deleted and can not be recovered. Furthermore, if the model becomes unavailable during the conversation, the frontend will return to show the message that the model is currently not running. This also results in the chat history being lost. While Aitta tries to ensure that a model is always running when you are actively using, it can happen that the current allocation of resources expires before Aitta is able to obtain a new allocation.
+The web frontend is only a basic chat interface with no additional features. The entire chat history is kept in your browser. If you leave the page, the conversation is deleted and can not be recovered. Furthermore, if the model becomes unavailable during the conversation, the frontend will return to show the message that the model is currently not running. This also results in the chat history being lost. While Aitta tries to ensure that a model is always running when you are actively using it, it can happen that the current allocation of resources expires before Aitta is able to obtain a new allocation.
 
 The frontend also performs no automatic compaction of the history. If the length of the conversation exceeds the capabilities of the underlying model, it will stop responding and you may encounter an error message.
 
@@ -205,7 +205,7 @@ The PyPI package [aitta-client][aitta-client-pypi] contains functions for intera
 
 ### API reference
 
-This section gives a broad overview of the available API functionality. To check a detailed reference for parameters and example usage, refer to the automated Swagger API reference at [api-aitta.csc.fi/docs][aitta-api-docs].
+This section gives a broad overview of the available API functionality. To check a detailed reference for parameters and example usage, refer to the automated Swagger API reference at [aitta-api.csc.fi/docs][aitta-api-docs].
 
 Responses from the Aitta API are typically JSON objects following the Hypertext Application Language (HAL) specification, which in every response includes URLs to further endpoints relevant to the requested resource. This allows you to write client code that follows the URLs linked from the responses based on semantic names for resource endpoints instead of hardcoding URLs in your code.
 
@@ -244,7 +244,7 @@ The API exposes details about available models. You can get a list of available 
 }
 ```
 
-The response of the model information endpoint is a JSON object containing a description of the model as well as a list of the models capabilities, indicating which inference endpoints are supported for the model. It also includes a list of URLs relevant to the model, including e.g. the OpenAI compatible inference endpoints the model supports as well as the URL of the endpoint listing currently active workers for the model. An example response for the `openai/gpt-oss-120b` model looks like the following:
+The response of the model information endpoint is a JSON object containing a description of the model as well as a list of the model's capabilities, indicating which inference endpoints are supported for the model. It also includes a list of URLs relevant to the model, including e.g. the OpenAI compatible inference endpoints the model supports as well as the URL of the endpoint listing currently active workers for the model. An example response for the `openai/gpt-oss-120b` model looks like the following:
 
 ```json
 {

--- a/docs/laif/inference/index.md
+++ b/docs/laif/inference/index.md
@@ -7,7 +7,7 @@
 [ai-environment]: ../software/ai-environment.md
 [ai-guide-vllm]: https://github.com/Lumi-supercomputer/LUMI-AI-Guide/tree/main/10-LLM-inference
 
-AI-enabled services at their core rely on a trained machine learning model that predict an output based on the given input. A prominent example is when a large language model (LLM) generates a chat response based on the full log of the previous conversation and potentially some additonal context information for use in an AI chat assistant application. This prediction process is referered to as `inference`.
+AI-enabled services at their core rely on a trained machine learning model that predicts an output based on the given input. A prominent example is when a large language model (LLM) generates a chat response based on the full log of the previous conversation and potentially some additional context information for use in an AI chat assistant application. This prediction process is referred to as `inference`.
 
 An `inference service` (or server) is a software process that performs inference upon request from a downstream application and thus forms a core component of an AI application. The inference service hides the complexity of running the actual models, which due to their size often require several GPUs or even several entire LUMI-G compute nodes, behind an abstracted interface. This typically takes the form of semantic HTTP endpoints, like the [OpenAI API][openai-api-reference], which has become a de-facto standard.
 
@@ -25,7 +25,7 @@ The Aitta service frontpage is available at [aitta.csc.fi][aitta] and detailed u
 
 ### Self-hosted Inference Servers
 
-You can also run your own inference server like [vLLM][vllm], which is available in the [LUMI AI Factory AI Software Enviroment][ai-environment], or similar. This gives you full control over the inference server and the ability to perform inference with any model you desire. It also ensures that you have the server for yourself and no other user has access to it, giving you sole access to the compute power of the reserved GPUs (e.g. for processing large batches of data at once).
+You can also run your own inference server like [vLLM][vllm], which is available in the [LUMI AI Factory AI Software Environment][ai-environment], or similar. This gives you full control over the inference server and the ability to perform inference with any model you desire. It also ensures that you have the server for yourself and no other user has access to it, giving you sole access to the compute power of the reserved GPUs (e.g. for processing large batches of data at once).
 
 However, it also has a few drawbacks:
 

--- a/docs/laif/software/agent-infrastructure.md
+++ b/docs/laif/software/agent-infrastructure.md
@@ -72,7 +72,7 @@ module load Local-LAIF lumi-aif-agents
 opencode
 ```
 
-Your home directory, as well as any project directories under, e.g, `/scratch`,
+Your home directory, as well as any project directories under, e.g., `/scratch`,
 are not mounted in the container environment by default. If you wish OpenCode to have access to
 directories that are not under your current working directory, you can bind mount them by appending
 them to the `SINGULARITY_BIND` environment variable.

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -12,7 +12,7 @@
 
 The AI Software Environment by LUMI AI Factory is a comprehensive, ready-to-use containerised stack for AI
 and machine learning workloads on the LUMI supercomputer. The environment is designed to address
-the complexity of deploying and maintaining AI/ML software in high-performance computing (HPC)
+the complexity of deploying and maintaining AI/ML software in a high-performance computing (HPC)
 settings.
 
 All build artifacts are publicly available. This includes the full recipe,

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -13,7 +13,7 @@
 The AI Software Environment by LUMI AI Factory is a comprehensive, ready-to-use containerised stack for AI
 and machine learning workloads on the LUMI supercomputer. The environment is designed to address
 the complexity of deploying and maintaining AI/ML software in a high-performance computing (HPC)
-settings.
+setting.
 
 All build artifacts are publicly available. This includes the full recipe,
 Containerfiles, build logs, and the resulting final container images. This

--- a/docs/laif/software/ai-environment.md
+++ b/docs/laif/software/ai-environment.md
@@ -13,7 +13,7 @@
 The AI Software Environment by LUMI AI Factory is a comprehensive, ready-to-use containerised stack for AI
 and machine learning workloads on the LUMI supercomputer. The environment is designed to address
 the complexity of deploying and maintaining AI/ML software in high-performance computing (HPC)
-setting.
+settings.
 
 All build artifacts are publicly available. This includes the full recipe,
 Containerfiles, build logs, and the resulting final container images. This
@@ -109,7 +109,7 @@ This will create an h5-env environment in the working directory. The `--system-s
 !!! Warning "Strain on Lustre file system"
     Installing Python packages typically creates thousands of small files. This puts a lot of strain on the Lustre file system and might exceed your file quota. This problem can be solved by [building new containers based on the images](#build-new-containers-based-on-the-images).
 
-Now one can execute a script with and import the h5py package. To execute a script called `my-script.py` within the container using the virtual environment, use the additional activation command:
+Now one can execute a script that imports the h5py package. To execute a script called `my-script.py` within the container using the virtual environment, use the additional activation command:
 
 ```
 export SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260124_092648/lumi-multitorch-full-u24r64f21m43t29-20260124_092648.sif
@@ -126,7 +126,7 @@ To build a new container the following steps are required:
 
 1. Check what software you want to install.
 
-    *Note: For a few small pip packages a [virtual environment](#list-pip-packages-in-container) might be sufficient.*
+    *Note: For a few small pip packages a [virtual environment](#add-more-pip-packages-to-container) might be sufficient.*
 
 
 2. Identify the correct base container from the [releases on GitHub][releases on GitHub].
@@ -170,7 +170,7 @@ To build a new container the following steps are required:
 4. Build the container using the [instructions to extend singularity images](../../software/containers/singularity.md). This is possible either on your [own hardware](../../software/containers/singularity.md#building-containers-on-local-hardware) or directly on [LUMI using PRoot](../../software/containers/singularity.md#building-or-extending-containers-with-proot).
 
     !!! Warning "Memory requirements"
-        Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive.md/#interactive-slurm-jobs) with sufficient memory. 
+        Creating new containers based on the provided containers might require significant memory. One option is to use an [interactive slurm job](../../runjobs/scheduled-jobs/interactive.md#interactive-slurm-jobs) with sufficient memory. 
 
     Example:
 

--- a/docs/laif/software/index.md
+++ b/docs/laif/software/index.md
@@ -9,6 +9,6 @@ preview.
 
 Currently available tools and software:
 
-* [AI Software Enviroment](./ai-environment.md)
+* [AI Software Environment](./ai-environment.md)
 * [Containerized Workflows](./workflows.md)
 * [Infrastructure for AI agents](./agent-infrastructure.md)


### PR DESCRIPTION
Fixed some typos with the help of Opus 4.8. Most of them are straightforward, but some links were actually broken or wrong. :) 

Preview: https://lumi-supercomputer-docs-preview.rahtiapp.fi/origin/fix_lumi_aif_typos/laif/

26f8f8b — docs(laif): fix DaaS guide typos and links

  docs/laif/data/daas-guide.md
  - [software] reference retargeted: ./../../storage/index.md → ./../../software/index.md
  - Removed unused [software library] link reference
  - "you don't need have an account" → "need to have"
  - "some idea of AI useage" → "usage"
  


  3985254 — docs(laif): fix Aitta and inference typos, grammar, and link   @lupreCSC 
  
  docs/laif/inference/aitta.md
  - "We are hoping resolve this" → "hoping to resolve"
  - "it means that is already loaded" → "that it is already loaded"
  - "at the buttom of the page" → "bottom" (×2: alt text + figcaption)
  - "explicitely shut down" → "explicitly" 
  - "actively using, it can happen" → "actively using it, it can happen"
  - Swagger reference [api-aitta.csc.fi/docs] → [aitta-api.csc.fi/docs]
  - "a list of the models capabilities" → "the model's capabilities"
  
  docs/laif/inference/index.md
  - "model that predict" → "predicts"
  - "some additonal context" → "additional"
  - "referered to as" → "referred"
  - "AI Software Enviroment" → "Environment"
  


  c8c742b — docs(laif): fix agent infrastructure typo @mitjasai:
  
  docs/laif/software/agent-infrastructure.md
  - "under, e.g, /scratch" → "e.g.,"
  
  133a052 — docs(laif): fix AI environment anchors and typos @mitjasai:
  
  docs/laif/software/ai-environment.md
  - Note anchor #list-pip-packages-in-container → #add-more-pip-packages-to-container
  - Interactive-job link: removed stray slash interactive.md/#… → interactive.md#… (This doesn't really matter, link seems to work fine either way).
  - "in high-performance computing (HPC) setting" → "settings"
  - "execute a script with and import the h5py package" → "a script that imports the h5py package"
  
  docs/laif/software/index.md
  - "AI Software Enviroment" → "Environment"
