### PR TITLE
Update Spack documentation for the partition-based Spack 1.1 setup

### DIFF
--- a/docs/runjobs/lumi_env/Lmod_modules.md
+++ b/docs/runjobs/lumi_env/Lmod_modules.md
@@ -195,8 +195,9 @@ The `module spider` command has three levels, producing different outputs:
     versions of `CMake` (3.27.7, 3.29.3, 3.31.7, 3.31.77 and 4.2.3) 
     are available on the system as
     extensions of another module.
-    If you have one of the `spack` modules loaded, you may see a line "Other
-    possible matches" with some lowercase modulenames that contain the string "cmake".
+    If you have one of the Spack modules (`spack-cpu` or `spack-gpu`) loaded, you
+    may see a line "Other possible matches" with some lowercase modulenames that
+    contain the string "cmake".
 
     !!! info "Information on LUMI software stacks?"
         For more information on the software stacks on LUMI, head to the

--- a/docs/runjobs/lumi_env/softwarestacks.md
+++ b/docs/runjobs/lumi_env/softwarestacks.md
@@ -42,8 +42,9 @@ On LUMI, four types of software stacks are currently offered:
     integrate in the central stack (even the corresponding modules will be made
     available automatically).
 
--   `spack` is an extensible software stack based on the 
-    [Spack package manager][spack-site]. You can read more about Spack on LUMI
+-   `spack-cpu` and `spack-gpu` are extensible software stacks based on the
+    [Spack package manager][spack-site], one for the CPU partition and one for
+    the GPU partition. You can read more about Spack on LUMI
     on [the "Spack" page in the "Software" section][spack-in-docs].
     Spack is offered "as-is" for users experienced in the use of Spack, but
     properly pre-configured to use compilers and some libraries already installed
@@ -90,11 +91,11 @@ $ module avail
 ... some lines removed here
 
 ----------------------------- Software stacks -----------------------------
-   CrayEnv    (S)    LUMI/23.12            (S)      spack/22.08-2
-   LUMI/22.08 (S)    LUMI/24.03            (S,D)    spack/23.03
-   LUMI/22.12 (S)    Local-CSC/default     (S)      spack/23.03-2
-   LUMI/23.03 (S)    Local-quantum/default (S)      spack/23.09   (D)
-   LUMI/23.09 (S)    spack/22.08
+   CrayEnv    (S)    LUMI/23.12            (S)      spack-cpu/1.1
+   LUMI/22.08 (S)    LUMI/24.03            (S,D)    spack-gpu/1.1
+   LUMI/22.12 (S)    Local-CSC/default     (S)
+   LUMI/23.03 (S)    Local-quantum/default (S)
+   LUMI/23.09 (S)
 
 --------------------- Modify the module display style ---------------------
    ModuleColour/off      (S)      ModuleLabel/label       (S,L,D)
@@ -122,7 +123,7 @@ software stack.
 
 The *Software stacks* block in the output shows the available software stacks:
 `CrayEnv`, 6 versions of the `LUMI` stack, 
-5 versions of the `spack` stack,
+the two Spack stacks `spack-cpu` and `spack-gpu`,
 and two stack modules whose name starts with `Local-` 
 in this example. The `(S)` besides the
 name shows that these are sticky modules that won't be removed by default by

--- a/docs/software/installing/spack.md
+++ b/docs/software/installing/spack.md
@@ -8,127 +8,200 @@ useful for building and maintaining installations of many different versions of
 the same software. It also comes with a virtual environment feature that is
 useful when developing software.
 
-LUMI provides a module to load a pre-configured Spack instance: `module load spack`. When you load this module, you will use a Spack instance configured to compile software with the Cray programming environment. The software will be installed in a location determined by you in the environmental variable `$SPACK_USER_PREFIX`. This Spack instance is "chained" to the upstream instance in `/appl/lumi/spack`, which means that you can build new packages on top of the already installed ones by the LUMI User Support Team (similar to how the LUMI EasyBuild setup works).
+LUMI provides pre-configured Spack instances as Lmod modules, one per compute
+partition: `spack-cpu/1.1` for the LUMI-C (CPU) nodes and `spack-gpu/1.1` for
+the LUMI-G (GPU) nodes. The version number (`1.1`) is the Spack release version.
 
-!!! important "The software installed with Spack in /appl/lumi/spack/ is provided as is."
-    It may not have received any testing after installation! We also build the
-    software there in a more fool-proof way with slightly less optimization:
-    Zen2 architecture instead of Zen3, OpenBLAS instead of Cray LibSci, and
-    Netlib Scalapack. This may have a small impact on performance, but is
-    usually fine.
+Both modules reuse the compilers and system libraries already present on LUMI —
+from the Cray Programming Environment and from the operating system — rather
+than rebuilding them, and both install the software you build into a location
+you control through the environment variable `$SPACK_USER_PREFIX`.
 
-## Using Spack on LUMI
+!!! important "The `spack-cpu` and `spack-gpu` modules belong to the `LUMI_SoftwareStack` family."
+    Loading one automatically unloads the other, and both conflict with the
+    LUMI software stacks (`CrayEnv`, `LUMI/<version>`). Use one software stack
+    per shell session — either a Spack module or a LUMI stack, not both.
+
+## What the Spack modules provide
+
+The setup is organized per compute partition rather than per Cray Programming
+Environment release: a single configuration lists every compiler installed on
+the system, so it is not tied to one CPE version.
+
+* `spack-cpu/1.1` — for the LUMI-C CPU nodes. It uses the system `libfabric`
+  and builds `mpich`/`openmpi` without GPU support.
+* `spack-gpu/1.1` — for the LUMI-G GPU nodes. Everything in the CPU
+  configuration, plus the AMD ROCm/HIP stack as external packages (currently
+  ROCm 6.3.4, from `/opt/rocm-6.3.4`), the AMD `llvm-amdgpu` compiler, and
+  `+rocm amdgpu_target=gfx90a` applied by default so that packages are built for
+  the MI250X GPUs.
+
+Both modules share the following defaults:
+
+* **Compilers** (all external, from the Cray Programming Environment or the
+  system): `gcc@14.3.0` (the default), `gcc@12.2.0`, `gcc@7.5.0`, `cce@20.0.0`
+  and `cce@19.0.0`. The GPU module additionally offers `llvm-amdgpu@6.3.4`. The
+  default compiler is a soft preference — you can override it per spec with
+  `%<compiler>@<version>`.
+* **Target microarchitecture** `zen3`, matching the LUMI compute nodes. The
+  concretizer is configured with `host_compatible: false` so that you can
+  concretize and build for the Zen3 compute nodes from the Zen2 login nodes.
+* **BLAS/LAPACK** provided by OpenBLAS, and **MPI** by `mpich` (preferred) or
+  `openmpi`.
+
+## Installing software
 
 **To install software with Spack**, perform the following steps. In this
 example, we will install [kokkos](https://kokkos.org/about/), a C++ parallel
-programming framework, into a hypothetical project storage folder
-`/project/project_465000XYZ/spack`. We want to configure this package with AMD
-GPU support and activate extra array bounds checking for debugging.
+programming framework, with AMD GPU support and extra array bounds checking for
+debugging, into a project storage folder `/project/project_465000XYZ/spack`.
 
-1. Initialize Spack.
+1. Load the Spack module for the partition you are targeting. Because we want a
+   GPU build, we use `spack-gpu`:
 
     ```bash
-    $ export SPACK_USER_PREFIX=/project/project_465000XYZ/spack 
-    $ module load spack/23.09
+    $ export SPACK_USER_PREFIX=/project/project_465000XYZ/spack
+    $ module load spack-gpu/1.1
     ```
 
-    We recommend that you set `$SPACK_USER_PREFIX` in e.g. your `.bash_profile`
-    file to avoid having to set it every time you want to use Spack.
+    `$SPACK_USER_PREFIX` determines where your installed packages, generated
+    modules, caches and environments are stored. If you do not set it, it
+    defaults to `$HOME/spack-prefix`. Because software installations can grow
+    large and your home directory has a small quota, we recommend pointing it at
+    a project or scratch folder, and setting it in e.g. your `.bash_profile` so
+    you do not have to set it every time. The module creates the
+    `install/`, `cache/`, `modules/` and `environments/` subdirectories under
+    the prefix automatically when it is loaded.
 
-2. Check the information Spack has about the package and especially the
+2. Check the information Spack has about the package, especially the
    configuration options:
 
     ```bash
     $ spack info kokkos
     ```
 
-    From reading the package information, it becomes clear that the install command should be:
+    From reading the package information, the install command becomes:
 
     ```bash
-    $ spack install kokkos+rocm+debug_bounds_check amdgpu_target==gfx90a %gcc@12.2.0
+    $ spack install kokkos +debug_bounds_check
     ```
 
-    The flag `+rocm` activates GPU support, and `+debug_bounds_check` adds the
-    array bounds checking. We also need to specify the type of GPU:
-    `amdgpu_target==gfx90a` (note the double equal signs which has the special meaning of propagating the GPU target to all dependencies). In this case, we give no explicit specification of a compiler, which means that Spack will choose gcc 11.2.0 for us when compiling.
-    
+    The flag `+debug_bounds_check` adds the array bounds checking. Note that we
+    do **not** have to pass `+rocm`, the GPU target, or the CPU microarchitecture:
+    the `spack-gpu` module applies `+rocm amdgpu_target=gfx90a` (the LUMI-G MI250X
+    GPUs) and `target=zen3` (the LUMI-G compute-node CPU) as defaults. We also
+    give no explicit compiler, so Spack uses the default `gcc@14.3.0`. To pick a
+    different compiler, append e.g. `%cce@20.0.0` or `%llvm-amdgpu@6.3.4` to the
+    spec.
+
 3. Before installing, it is good practice to check the dependencies that Spack
-   will install. Sometimes this can be many, many, packages! Running this
+   will install. Sometimes this can be many, many packages! Running this
    command can take some time (up to a few minutes):
 
     ```console
-    $ spack spec -I kokkos+rocm+debug_bounds_check amdgpu_target==gfx90a %gcc@12.2.0
-    Input spec
-    --------------------------------
-    -   kokkos%gcc@12.2.0+debug_bounds_check+rocm amdgpu_target==gfx90a
-
+    $ spack spec -I kokkos +debug_bounds_check
+    ...
     Concretized
     --------------------------------
-    -   kokkos@4.1.00%gcc@12.2.0~aggressive_vectorization~compiler_warnings~cuda~debug+debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~openmptarget~pic+rocm+serial+shared~sycl~tests~threads~tuning~wrapper amdgpu_target=gfx90a build_system=cmake build_type=Release cxxstd=17 generator=make intel_gpu_arch=none arch=linux-sles15-zen2
-    [^]      ^cmake@3.27.7%gcc@12.2.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen2
-    [^]          ^curl@8.4.0%gcc@12.2.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-zen2
-    [^]              ^nghttp2@1.57.0%gcc@12.2.0 build_system=autotools arch=linux-sles15-zen2
-    [^]              ^openssl@3.1.3%gcc@12.2.0~docs+shared build_system=generic certs=mozilla arch=linux-sles15-zen2
-    [^]                  ^ca-certificates-mozilla@2023-05-30%gcc@12.2.0 build_system=generic arch=linux-sles15-zen2
-    [^]                  ^perl@5.38.0%gcc@12.2.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-sles15-zen2
-    [^]                      ^berkeley-db@18.1.40%gcc@12.2.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-sles15-zen2
-    [^]                      ^bzip2@1.0.8%gcc@12.2.0~debug~pic+shared build_system=generic arch=linux-sles15-zen2
-    [^]                          ^diffutils@3.9%gcc@12.2.0 build_system=autotools arch=linux-sles15-zen2
-    [^]                              ^libiconv@1.17%gcc@12.2.0 build_system=autotools libs=shared,static arch=linux-sles15-zen2
-    [^]                      ^gdbm@1.23%gcc@12.2.0 build_system=autotools arch=linux-sles15-zen2
-    [^]                          ^readline@8.2%gcc@12.2.0 build_system=autotools patches=bbf97f1 arch=linux-sles15-zen2
-    [^]              ^pkgconf@1.9.5%gcc@12.2.0 build_system=autotools arch=linux-sles15-zen2
-    [^]          ^ncurses@6.4%gcc@12.2.0~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-zen2
-    [^]          ^zlib-ng@2.1.4%gcc@12.2.0+compat+opt build_system=autotools arch=linux-sles15-zen2
-    [^]      ^gmake@4.4.1%gcc@12.2.0~guile build_system=generic arch=linux-sles15-zen2
-    [e]      ^hip@5.6.1%gcc@12.2.0~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-zen2
-    [e]      ^hsa-rocr-dev@5.6.1%gcc@12.2.0+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-zen2
-    [e]      ^llvm-amdgpu@5.6.1%gcc@12.2.0~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,b66529f,d35aec9 arch=linux-sles15-zen2
-
+     -   kokkos@4.x.x%gcc@14.3.0 ~aggressive_vectorization ... +debug_bounds_check
+             +rocm +serial +shared amdgpu_target=gfx90a ... arch=linux-sles15-zen3
+    [e]      ^hip@6.3.4%gcc@14.3.0 ...
+    [e]      ^hsa-rocr-dev@6.3.4%gcc@14.3.0 ...
+    [e]      ^llvm-amdgpu@6.3.4%gcc@14.3.0 ...
+     -       ^cmake@3.xx.x%gcc@14.3.0 ...
     ...
-
     ```
 
-    The packages that are already installed in your own Spack instance will
-    have a `[+]` in the first column, and the packages that Spack found
-    installed upstream will have `[^]`. A `-` means Spack did not find the
-    package and will build it. External packages already installed in the operating system are marked with `[e]`.
-    In this case, all dependencies are already installed so building a new `kokkos` package will be fast.
+    Packages already installed in your Spack prefix show a `[+]` in the first
+    column. A `-` means Spack did not find the package and will build it.
+    Packages that are provided externally by the system are marked with `[e]`
+    and are used in place rather than rebuilt: the compilers, Slurm, `libfabric`,
+    `xpmem` and, on the GPU partition, the ROCm/HIP stack. MPI is not one of
+    them — Spack builds `mpich` or `openmpi` itself, on top of the system
+    `libfabric`.
 
 4. When you're satisfied with what Spack plans to do, install it:
 
     ```console
-    $ spack install kokkos+rocm+debug_bounds_check amdgpu_target==gfx90a %gcc@12.2.0
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/nghttp2-1.57.0-eeoiirs
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/zlib-ng-2.1.4-lky5mdq
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/ncurses-6.4-bd4kmia
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/gmake-4.4.1-upexb7o
-    [+] /appl/lumi/SW/CrayEnv/EB/rocm/5.6.1/hip (external hip-5.6.1-6dfpgvow3wgluedg7dkolvju5tqikf4a)
-    [+] /appl/lumi/SW/CrayEnv/EB/rocm/5.6.1 (external hsa-rocr-dev-5.6.1-kdk4dmdpcit6od7zd4c4anpe67tjazvv)
-    [+] /appl/lumi/SW/CrayEnv/EB/rocm/5.6.1/llvm (external llvm-amdgpu-5.6.1-lox2s3th5j6gtobnulhreq2xfyflres7)
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/openssl-3.1.3-g2j3rdw
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/curl-8.4.0-utgotfg
-    [+] /appl/lumi/spack/23.09/0.21.0/opt/spack/cmake-3.27.7-4amcecb
-    ==> Installing kokkos-4.1.00-gnre4vg6quv7syzovboykanhz5k5fyd5 [11/11]
-    ==> No binary for kokkos-4.1.00-gnre4vg6quv7syzovboykanhz5k5fyd5 found: installing from source
-    ==> Fetching https://mirror.spack.io/_source-cache/archive/cf/cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275.tar.gz
-    ==> No patches needed for kokkos
-    ==> kokkos: Executing phase: 'cmake'
-    ==> kokkos: Executing phase: 'build'
-    ==> kokkos: Executing phase: 'install'
-    ==> kokkos: Successfully installed kokkos-4.1.00-gnre4vg6quv7syzovboykanhz5k5fyd5
-      Stage: 0.73s.  Cmake: 22.42s.  Build: 17.69s.  Install: 6.34s.  Post-install: 2.22s.  Total: 51.52s
-    [+] /projappl/project_465000XYZ/spack/23.09/0.21.0/kokkos-4.1.00-gnre4vg
+    $ spack install kokkos +debug_bounds_check
+    ...
+    ==> Installing kokkos-... [n/n]
+    ==> kokkos: Successfully installed kokkos-...
+    [+] /project/project_465000XYZ/spack/install/kokkos-4.x.x-xxxxxxx
     ```
 
-    The final line shows where the software is installed on disk. A module will
-    also be generated automatically and added to your `$MODULEPATH`. The
-    modules are generated with a short hash code (3 characters `hcn` here) to
-    prevent name collisions.
+    The final line shows where the software is installed on disk, under
+    `$SPACK_USER_PREFIX/install`. A module is also generated automatically and
+    added to your `$MODULEPATH`. Module names follow the pattern
+    `<name>/<version>-<compiler>-<compiler version>-<hash>`, where the short hash
+    at the end prevents name collisions between different builds of the same
+    package and version:
 
     ```bash
-    $ module load kokkos/4.1.00-gcc-gnr
+    $ module load kokkos/4.x.x-gcc-14.3.0-abc
     ```
+
+    Modules are only generated for the packages you install explicitly.
+    Dependencies that Spack pulls in on its own do not get a module of their own.
+
+## Spack environments
+
+Instead of installing packages one by one, you can group a set of packages into
+a Spack [environment](https://spack.readthedocs.io/en/latest/environments.html).
+An environment concretizes all its specs together, so shared dependencies are
+guaranteed to match, and installs them as a unit. This is the recommended way to
+build a coherent stack of related packages:
+
+```bash
+$ spack env create my-env
+$ spack env activate my-env
+$ spack add kokkos +debug_bounds_check
+$ spack add hdf5
+$ spack concretize
+$ spack install
+```
+
+Environments are stored under `$SPACK_USER_PREFIX/environments`. For large
+environments you can let Spack build independent packages in parallel by
+generating a Makefile with `spack env depfile`:
+
+```bash
+$ spack env depfile -o Makefile
+$ make -j 16
+```
+
+## Customizing the configuration
+
+The LUMI modules occupy both of Spack's file-based configuration scopes with the
+central configuration (see [How the LUMI Spack setup
+works](#how-the-lumi-spack-setup-works) below), so no personal scope is left for
+you to edit. The way to change settings (compilers, variants, external packages)
+or to add your own package repository is therefore a **Spack environment**, whose
+`spack.yaml` takes precedence over both of them.
+
+For example, to create your own package repository and add it to an environment:
+
+```bash
+$ spack repo create /users/username/my-packages myrepo
+$ spack env activate my-env
+$ spack repo add /users/username/my-packages
+$ spack repo list
+```
+
+`spack repo list` prints one line per repository, showing its status, namespace,
+package API version and location. Your own repository is listed next to the
+built-in one, which Spack clones from
+[`spack-packages`](https://github.com/spack/spack-packages) into
+`~/.spack/package_repos/`.
+
+!!! note "Run `spack repo add` with an environment active"
+    `spack repo add` writes to whichever configuration scope is currently
+    modifiable. With an environment active, that is the environment's
+    `spack.yaml`. Without one, Spack tries to write to the partition
+    configuration under `/appl/lumi`, which is read-only, and the command fails.
+
+More information about creating package repositories is available in the
+[Spack documentation](https://spack.readthedocs.io/en/latest/repositories.html).
 
 ## What to do when a Spack install fails
 
@@ -141,7 +214,8 @@ GPU support and activate extra array bounds checking for debugging.
     Some failures can be avoided by:
 
     - building a different version of the packages
-    - building with a different compiler (try `%gcc` or `%cce`)
+    - building with a different compiler (try `%gcc`, `%cce` or, on the GPU
+      partition, `%llvm-amdgpu`)
     - disabling a variant of the package
     - modifying which dependencies are used to build the target package (see
       [Specs and
@@ -149,132 +223,95 @@ GPU support and activate extra array bounds checking for debugging.
       in the official Spack documentation)
 
     In some cases, changes have to be made to the `package.py` file of a package.
-    Unfortunately, this is not straightforward as the package repository is
-    located in `/appl/lumi`, which is read-only. In such cases, you have to either
-    make your own Spack instance and configure it using our configuration
-    files, or set up a custom Spack package repository and override the default Spack settings (see more below).
+    Editing the built-in recipes in place is not an option: as of Spack 1.0 they
+    are no longer part of the Spack source tree, but are cloned from the separate
+    [`spack-packages`](https://github.com/spack/spack-packages) repository into a
+    cache under `~/.spack/package_repos/` that Spack manages and overwrites.
+    Instead, set up your own Spack package repository and add it to a Spack
+    environment, as described under [Customizing the
+    configuration](#customizing-the-configuration).
 
-2. **Seek help:** you can check the 
-    [official Spack documentation](https://spack.readthedocs.io), open a ticket 
-    at the [LUMI Helpdesk](https://www.lumi-supercomputer.eu/user-support/need-help/) 
-    or ask the Spack community via the [Spack Slack](http://spackpm.slack.com), 
+2. **Seek help:** you can check the
+    [official Spack documentation](https://spack.readthedocs.io), open a ticket
+    at the [LUMI Helpdesk](https://www.lumi-supercomputer.eu/user-support/need-help/)
+    or ask the Spack community via the [Spack Slack](http://spackpm.slack.com),
     the Spack Slack community can be very helpful.
 
-## Description of the different Spack modules
+## How the LUMI Spack setup works
 
-* Module `spack/23.09`: This is Spack release version 0.21.0 (with some critical bug fixes for concretization backported from the 0.21.1 development branch) based on the Cray Programming Environment 23.09.
-  The ROCM packages are ROCM release version 5.6.1 adapted by the LUMI User Support Team for CPE 23.09.
-  Testing has indicated that it should be possible to run ROCM 5.6.1-based software using the older drivers from ROCM 5.2.3, which is installed on the LUMI-G compute nodes.
-  There are only minor incompatibilities, e.g. the amount of GPU memory might be reported incorrectly.
-* Module `spack/23.03-2`: This is Spack release version 0.20.0 based on the Cray Programming Environment 23.03.
-  The ROCM packages are built from source by Spack and corresponds to ROCM release version 5.4.3.
-  Testing has indicated that it should be possible to run ROCM 5.4.3-based software using the older drivers from ROCM 5.2.3, which is installed on the LUMI-G compute nodes.
-* Module `spack/23.03`: This is Spack release version 0.19.2 based on the Cray Programming Environment 23.03.
-  The ROCM packages are external and comes from the HPE provided ROCM 5.2.3 in `/opt/rocm`.
-* Module `spack/22.08-2`: This is Spack release version 0.19.0 based on the Cray Programming Environment 22.08.
-  The ROCM packages are built from source by Spack and corresponds to ROCM release version 5.2.3.
-  **This Spack module is deprecated and should not be used!**
-  Testing has indicated that it should be possible to run ROCM 5.2.3-based software using the older drivers from ROCM 5.1.3, which is installed on the LUMI-G compute nodes.
-* Module `spack/22.08`: This is Spack release version 0.18.1 based on the Cray Programming Environment 22.08.
-  The ROCM packages are external and comes from the HPE provided ROCM 5.0.2 in `/opt/rocm` (which is rather old).
-  **This Spack module is deprecated and should not be used!**
-  MPI programs may not work, and the linked ROCm is ancient and does not exist on the system anymore.
-
-## Spack on LUMI (advanced)
-
-This section further explains the Spack setup on LUMI.
-
-The upstream Spack instances maintained by the [User Support Team][helpdesk]
-are located in subdirectories of `/appl/lumi/spack`, numbered according to the
-Cray Programming Environment release version, and Spack release version. For
-example:
+The Spack installation maintained by the [User Support Team][helpdesk] lives
+under `/appl/lumi`, which is read-only for users:
 
 ```text
-/appl/lumi/spack/22.08/0.18.1/
+/appl/lumi/
+├── spack-1.1/                # Spack source tree (one directory per Spack version)
+└── lumi-spack-settings/      # LUMI configuration and the Lmod modulefiles
+    └── configs/
+        ├── common/           # shared: compilers, install tree, modules, providers
+        ├── partition-c/      # LUMI-C extras (libfabric, mpich/openmpi)
+        └── partition-g/      # LUMI-G extras (ROCm/HIP stack, GPU defaults, AMD compiler)
 ```
 
-This is a Spack instance based on Spack release 0.18.1 configured to use the
-compilers and MPI libraries from the Cray Programming Environment release
-22.08. In general, we will only install one or two versions of Spack per programming
-environment. **These instances are not meant to be used directly by users** as
-they are configured to install packages centrally, i.e. `spack install` will
-fail with permission errors, but you can copy the configuration files from
-there if you want to make your own Spack instance.
+When you load a Spack module, it points `$SPACK_ROOT` at the shared Spack source
+tree (`/appl/lumi/spack-1.1`) and layers the configuration on top through Spack's
+[configuration scopes](https://spack.readthedocs.io/en/latest/configuration.html):
 
-Instead, for users, there are "fake" chained Spack instances installed
-alongside these which are configured with install packages in a user-specified
-location. These instances have names which end in `-user`, e.g.:
+* the `configs/common` directory is used as the *system* scope
+  (`$SPACK_SYSTEM_CONFIG_PATH`),
+* the partition-specific directory (`configs/partition-c` or
+  `configs/partition-g`) is used as the *user* scope
+  (`$SPACK_USER_CONFIG_PATH`).
 
-```text
-/appl/lumi/spack/22.08/0.18.1-user/
-```
+Because the partition configuration takes the user scope, the module does **not**
+read a personal `~/.spack/` configuration — the partition config replaces it.
+This redirects the configuration scope only: `~/.spack/` remains Spack's user
+cache directory, and is where the built-in package repository gets cloned.
+The `config.yaml` in the common scope is what redirects the install tree, the
+download and build caches, the generated modules and the environments into your
+`$SPACK_USER_PREFIX`:
 
-This is what the `spack` modules use, and what you should use as user on the
-system if you do not want set up your own Spack instance. If you check the `etc/spack/config.yaml` inside, you will see that they set the `install_tree` property to a value provided by `$SPACK_USER_PREFIX`.
-
-```text
+```yaml
 config:
-    build_jobs: 32
-    install_path_scheme: '{name}-{version}-{hash:7}'
-    install_tree: $SPACK_USER_PREFIX/22.08/0.18.1
-    source_cache: $SPACK_USER_PREFIX/22.08/0.18.1/cache
-    misc_cache:   $SPACK_USER_PREFIX/22.08/0.18.1/cache
-    install_missing_compilers: false
-    suppress_gpg_warnings: true
+  build_jobs: 32
+  install_tree:
+    root: $SPACK_USER_PREFIX/install
+    projections:
+      all: '{name}-{version}-{hash:7}'
+    padded_length: 128
+  source_cache: $SPACK_USER_PREFIX/cache
+  misc_cache: $SPACK_USER_PREFIX/cache
+  environments_root: $SPACK_USER_PREFIX/environments
 ```
 
-A similar trick is used in the `modules.yaml` file to install modules in
-`$SPACK_USER_PREFIX/22.08/0.18.1/modules/tcl`.
+A similar redirection in `modules.yaml` generates the Lmod modules under
+`$SPACK_USER_PREFIX/modules/lmod` and places them in a flat `Core/` layout, so
+every generated module can be loaded straight away with `module load`, without
+having to load a compiler or MPI module first.
 
-```text
-modules:
-  default:
-    roots:
-      tcl: $SPACK_USER_PREFIX/22.08/0.18.1/modules/tcl
-    enable:
-      - tcl
-    tcl:
-      hash_length: 5
-      projections:
-        all: '{name}/{version}-{compiler.name}'
-```
-
-If you want to use Spack directly (without `module load spack`), you can source
-the Spack initialization scripts as usual. They can be found on disk in e.g.:
+If you want to use Spack directly (without `module load`), you can source the
+Spack initialization script from the shared source tree:
 
 ```bash
-$ source /appl/lumi/spack/22.08/0.18.1-user/share/spack/setup-env.sh
+$ source /appl/lumi/spack-1.1/share/spack/setup-env.sh
 ```
 
-You need to make sure that `$SPACK_USER_PREFIX` is set and that the
-`cache` and `modules/tcl` subdirectories exist within that directory.
+In that case you have to set `$SPACK_USER_PREFIX`, and point
+`$SPACK_SYSTEM_CONFIG_PATH` and `$SPACK_USER_CONFIG_PATH` at the appropriate
+`configs/common` and `configs/partition-<c|g>` directories yourself, otherwise
+Spack will not pick up the LUMI configuration.
 
-### Overriding the default settings in the Spack module
+### Inspecting the effective configuration
 
-The `spack` modules read the configuration files from the `/appl/lumi/spack/.../etc/` directory, which is read-only for users.
-To change the configuration files, you need to override the default settings by placing new configuration files (like `compilers.yaml` and `packages.yaml`) in the `$HOME/.spack/` directory and then unset the environment variable `$SPACK_DISABLE_LOCAL_CONFIG`.
-It will not work otherwise, because the Spack module on LUMI sets this variable to prevent accidental interference between any user-local Spack configuration and the system configuration.
+When something is not behaving as expected, these commands show what Spack is
+actually using and where each setting comes from:
 
-### Making a custom package repository
-
-Adding your own package repository can be done in a similar way to changing the configuration files. You can add your own `repos.yaml` file in the `~/.spack/` directory and then configure the path to your custom package directory inside that file:
-
+```bash
+$ spack config get packages      # merged effective packages configuration
+$ spack config get modules       # merged effective modules configuration
+$ spack config blame packages    # which file each setting comes from
+$ spack spec -I <spec>           # what the concretizer picks for a spec
+$ spack arch                     # the architecture of the current node
 ```
-$ cat ~/.spack/repos.yaml
-repos:
-- /users/username/spack-packages
-```
-
-When `$SPACK_DISABLE_LOCAL_CONFIG` is unset, Spack will read this configuration file and pick up your private Spack repository. You can verify that Spack is seeing the new package repository by running the `spack repo list` command:
-
-```
- $ spack repo list
-==> 2 package repositories.
-custom     /users/username/spack-packages
-builtin    /pfs/lustrep3/appl/lumi/spack/23.03/0.20.0-user/var/spack/repos/builtin
-```
-
-More information about creating package repositories is available in the [Spack documentation](https://spack.readthedocs.io/en/latest/repositories.html).
 
 ## Further reading
 


### PR DESCRIPTION
Rewrites the Spack documentation to match the reorganised setup from [lumi-spack-settings#4](https://github.com/Lumi-supercomputer/lumi-spack-settings/pull/4), which replaced the CPE-versioned config tree with a partition-based, CPE-independent layout for Spack 1.1.

The old `spack/<CPE-version>` modules are gone, replaced by `spack-cpu/1.1` and `spack-gpu/1.1`. Everything downstream of that changed too: `$SPACK_USER_PREFIX` now has a default and a new internal layout, the configuration is layered through Spack's system and user scopes instead of upstream chaining, and there is no central pre-installed software to inherit from any more.